### PR TITLE
Fix typed route for homepage quick links

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,16 +1,15 @@
 
+import type { Route } from "next";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { BodyText, Heading, Subheading } from "@/components/ui/typography";
 
-const quickLinks = [
-
+const quickLinks: Array<{ title: string; description: string; href: Route }> = [
   { title: "Gi", description: "Støtt arbeidet med et engangsgave eller fast støtte.", href: "/gi" },
   { title: "Besøk oss", description: "Finn tid, sted og praktisk informasjon.", href: "/om-oss" },
   { title: "Meld deg på", description: "Påmelding til samlinger og arrangement.", href: "/kalender" },
-
 ];
 
 const news = [


### PR DESCRIPTION
### Motivation
- Ensure `Link` usages with `quickLinks` satisfy Next.js typed routes by providing a `Route`-typed `href` to avoid TypeScript errors.

### Description
- Add `import type { Route } from "next"` and annotate `quickLinks` as `Array<{ title: string; description: string; href: Route }>` so each `href` is typed correctly.

### Testing
- No automated tests or CI builds were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e100660d08324b1f795f8c9efd85d)