### PR TITLE
Add missing public pages for typed routes (/gi, /om-oss)

### DIFF
--- a/app/(public)/gi/page.tsx
+++ b/app/(public)/gi/page.tsx
@@ -1,0 +1,11 @@
+export default function GivePage() {
+  return (
+    <section className="container-layout py-16">
+      <h1 className="text-3xl font-semibold text-slate-900">Gi</h1>
+      <p className="mt-4 max-w-2xl text-slate-600">
+        Tusen takk for at du vurderer å støtte arbeidet vårt. Vi tilbyr både engangsgaver og
+        faste avtaler, og du kan ta kontakt hvis du ønsker hjelp til å komme i gang.
+      </p>
+    </section>
+  );
+}

--- a/app/(public)/om-oss/page.tsx
+++ b/app/(public)/om-oss/page.tsx
@@ -1,0 +1,11 @@
+export default function AboutPage() {
+  return (
+    <section className="container-layout py-16">
+      <h1 className="text-3xl font-semibold text-slate-900">Om oss</h1>
+      <p className="mt-4 max-w-2xl text-slate-600">
+        Bykirken er et fellesskap midt i byen. Vi ønsker å bygge relasjoner, tro og håp
+        gjennom samlinger, omsorgsarbeid og lokalt engasjement.
+      </p>
+    </section>
+  );
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
@@ -12,13 +12,13 @@ export function createSupabaseServerClient() {
 
   return createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
-      get(name) {
+      get(name: string) {
         return cookieStore.get(name)?.value;
       },
-      set(name, value, options) {
+      set(name: string, value: string, options: CookieOptions) {
         cookieStore.set({ name, value, ...options });
       },
-      remove(name, options) {
+      remove(name: string, options: CookieOptions) {
         cookieStore.set({ name, value: "", ...options });
       },
     },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
@@ -18,13 +18,13 @@ export async function middleware(request: NextRequest) {
 
     const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
       cookies: {
-        get(name) {
+        get(name: string) {
           return request.cookies.get(name)?.value;
         },
-        set(name, value, options) {
+        set(name: string, value: string, options: CookieOptions) {
           response.cookies.set({ name, value, ...options });
         },
-        remove(name, options) {
+        remove(name: string, options: CookieOptions) {
           response.cookies.set({ name, value: "", ...options });
         },
       },


### PR DESCRIPTION
### Motivation
- Fix a build/type error caused by missing typed routes where `"/gi"` and `"/om-oss"` were not represented by page files, which caused Next.js typedRoutes validation to fail during Vercel builds.

### Description
- Add `app/(public)/gi/page.tsx` with a simple `GivePage` placeholder to satisfy the `/gi` route.
- Add `app/(public)/om-oss/page.tsx` with a simple `AboutPage` placeholder to satisfy the `/om-oss` route.

### Testing
- Ran `npm run dev -- --hostname 0.0.0.0 --port 3000`, which started Next.js but compilation failed due to a missing module `@supabase/ssr` (module not found).
- Executed an automated Playwright script to visit `/gi` and capture a screenshot, which produced an artifact but the request returned `404` because the middleware/module error prevented normal routing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e38fe71848324a139be04fec07d13)