### PR TITLE
Add search filters to admin list views

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -13,12 +13,23 @@ function formatDate(value: string | null) {
   }).format(date);
 }
 
-export default async function EventsPage() {
+export default async function EventsPage({
+  searchParams,
+}: {
+  searchParams?: { query?: string };
+}) {
   const supabase = createSupabaseServerClient();
-  const { data: events } = await supabase
+  const query = searchParams?.query?.trim();
+  let request = supabase
     .from("events")
     .select("id, slug, title, status, start_time, end_time")
     .order("start_time", { ascending: false });
+  if (query) {
+    request = request.or(
+      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+    );
+  }
+  const { data: events } = await request;
 
   return (
     <div className="space-y-6">
@@ -36,6 +47,24 @@ export default async function EventsPage() {
           Nytt arrangement
         </Link>
       </div>
+
+      <form className="flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-200">
+          Søk
+          <input
+            name="query"
+            defaultValue={query}
+            placeholder="Søk i tittel eller slug"
+            className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-6 rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+        >
+          Filtrer
+        </button>
+      </form>
 
       <div className="overflow-hidden rounded-2xl border border-slate-800">
         <table className="w-full text-sm">

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { escapePostgrestText } from "@/lib/supabase/postgrest";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDate(value: string | null) {
@@ -20,13 +21,14 @@ export default async function EventsPage({
 }) {
   const supabase = createSupabaseServerClient();
   const query = searchParams?.query?.trim();
+  const escapedQuery = query ? escapePostgrestText(query) : null;
   let request = supabase
     .from("events")
     .select("id, slug, title, status, start_time, end_time")
     .order("start_time", { ascending: false });
-  if (query) {
+  if (escapedQuery) {
     request = request.or(
-      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+      `slug.ilike."%${escapedQuery}%",title->>no.ilike."%${escapedQuery}%"`
     );
   }
   const { data: events } = await request;

--- a/app/admin/pages/page.tsx
+++ b/app/admin/pages/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { escapePostgrestText } from "@/lib/supabase/postgrest";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDate(value: string | null) {
@@ -20,13 +21,14 @@ export default async function PagesPage({
 }) {
   const supabase = createSupabaseServerClient();
   const query = searchParams?.query?.trim();
+  const escapedQuery = query ? escapePostgrestText(query) : null;
   let request = supabase
     .from("pages")
     .select("id, slug, title, status, updated_at, published_at")
     .order("updated_at", { ascending: false });
-  if (query) {
+  if (escapedQuery) {
     request = request.or(
-      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+      `slug.ilike."%${escapedQuery}%",title->>no.ilike."%${escapedQuery}%"`
     );
   }
   const { data: pages } = await request;

--- a/app/admin/pages/page.tsx
+++ b/app/admin/pages/page.tsx
@@ -13,12 +13,23 @@ function formatDate(value: string | null) {
   }).format(date);
 }
 
-export default async function PagesPage() {
+export default async function PagesPage({
+  searchParams,
+}: {
+  searchParams?: { query?: string };
+}) {
   const supabase = createSupabaseServerClient();
-  const { data: pages } = await supabase
+  const query = searchParams?.query?.trim();
+  let request = supabase
     .from("pages")
     .select("id, slug, title, status, updated_at, published_at")
     .order("updated_at", { ascending: false });
+  if (query) {
+    request = request.or(
+      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+    );
+  }
+  const { data: pages } = await request;
 
   return (
     <div className="space-y-6">
@@ -36,6 +47,24 @@ export default async function PagesPage() {
           Ny side
         </Link>
       </div>
+
+      <form className="flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-200">
+          Søk
+          <input
+            name="query"
+            defaultValue={query}
+            placeholder="Søk i tittel eller slug"
+            className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-6 rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+        >
+          Filtrer
+        </button>
+      </form>
 
       <div className="overflow-hidden rounded-2xl border border-slate-800">
         <table className="w-full text-sm">

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { escapePostgrestText } from "@/lib/supabase/postgrest";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDate(value: string | null) {
@@ -20,13 +21,14 @@ export default async function PostsPage({
 }) {
   const supabase = createSupabaseServerClient();
   const query = searchParams?.query?.trim();
+  const escapedQuery = query ? escapePostgrestText(query) : null;
   let request = supabase
     .from("posts")
     .select("id, slug, title, status, updated_at, published_at")
     .order("updated_at", { ascending: false });
-  if (query) {
+  if (escapedQuery) {
     request = request.or(
-      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+      `slug.ilike."%${escapedQuery}%",title->>no.ilike."%${escapedQuery}%"`
     );
   }
   const { data: posts } = await request;

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -13,12 +13,23 @@ function formatDate(value: string | null) {
   }).format(date);
 }
 
-export default async function PostsPage() {
+export default async function PostsPage({
+  searchParams,
+}: {
+  searchParams?: { query?: string };
+}) {
   const supabase = createSupabaseServerClient();
-  const { data: posts } = await supabase
+  const query = searchParams?.query?.trim();
+  let request = supabase
     .from("posts")
     .select("id, slug, title, status, updated_at, published_at")
     .order("updated_at", { ascending: false });
+  if (query) {
+    request = request.or(
+      `slug.ilike.%${query}%,title->>no.ilike.%${query}%`
+    );
+  }
+  const { data: posts } = await request;
 
   return (
     <div className="space-y-6">
@@ -36,6 +47,24 @@ export default async function PostsPage() {
           Nytt innlegg
         </Link>
       </div>
+
+      <form className="flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-200">
+          Søk
+          <input
+            name="query"
+            defaultValue={query}
+            placeholder="Søk i tittel eller slug"
+            className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-6 rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+        >
+          Filtrer
+        </button>
+      </form>
 
       <div className="overflow-hidden rounded-2xl border border-slate-800">
         <table className="w-full text-sm">

--- a/app/admin/sermons/page.tsx
+++ b/app/admin/sermons/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { escapePostgrestText } from "@/lib/supabase/postgrest";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDate(value: string | null) {
@@ -20,13 +21,14 @@ export default async function SermonsPage({
 }) {
   const supabase = createSupabaseServerClient();
   const query = searchParams?.query?.trim();
+  const escapedQuery = query ? escapePostgrestText(query) : null;
   let request = supabase
     .from("sermons")
     .select("id, slug, title, preacher, published_at")
     .order("published_at", { ascending: false });
-  if (query) {
+  if (escapedQuery) {
     request = request.or(
-      `slug.ilike.%${query}%,title.ilike.%${query}%,preacher.ilike.%${query}%`
+      `slug.ilike."%${escapedQuery}%",title.ilike."%${escapedQuery}%",preacher.ilike."%${escapedQuery}%"`
     );
   }
   const { data: sermons } = await request;

--- a/app/admin/sermons/page.tsx
+++ b/app/admin/sermons/page.tsx
@@ -13,12 +13,23 @@ function formatDate(value: string | null) {
   }).format(date);
 }
 
-export default async function SermonsPage() {
+export default async function SermonsPage({
+  searchParams,
+}: {
+  searchParams?: { query?: string };
+}) {
   const supabase = createSupabaseServerClient();
-  const { data: sermons } = await supabase
+  const query = searchParams?.query?.trim();
+  let request = supabase
     .from("sermons")
     .select("id, slug, title, preacher, published_at")
     .order("published_at", { ascending: false });
+  if (query) {
+    request = request.or(
+      `slug.ilike.%${query}%,title.ilike.%${query}%,preacher.ilike.%${query}%`
+    );
+  }
+  const { data: sermons } = await request;
 
   return (
     <div className="space-y-6">
@@ -36,6 +47,24 @@ export default async function SermonsPage() {
           Ny tale
         </Link>
       </div>
+
+      <form className="flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-200">
+          Søk
+          <input
+            name="query"
+            defaultValue={query}
+            placeholder="Søk i tittel, slug eller taler"
+            className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-6 rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+        >
+          Filtrer
+        </button>
+      </form>
 
       <div className="overflow-hidden rounded-2xl border border-slate-800">
         <table className="w-full text-sm">

--- a/lib/supabase/postgrest.ts
+++ b/lib/supabase/postgrest.ts
@@ -1,0 +1,3 @@
+export function escapePostgrestText(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}


### PR DESCRIPTION
### Motivation
- Improve admin UX by allowing filtering/searching of content lists (posts, events, sermons, pages) directly from their list views.
- Enable server-side filtering so only matching rows are requested from Supabase rather than filtering client-side.

### Description
- Updated admin list pages (`app/admin/posts/page.tsx`, `app/admin/events/page.tsx`, `app/admin/sermons/page.tsx`, `app/admin/pages/page.tsx`) to accept `searchParams` and derive a trimmed `query` string.
- Built the Supabase request incrementally using a `request` variable and applied `.or(...)` with `ilike` (and `title->>no` JSON access for localized titles) when `query` is present.
- Added a simple search form (input named `query` and submit button) above each table to allow submitting filter queries via the page URL.
- Adjusted data fetching to await the composed `request` so results reflect the applied filter.

### Testing
- Ran the dev server with `npm run dev`, which failed due to missing Supabase `URL`/`KEY` environment variables and middleware error (expected in the current local environment). 
- Executed a Playwright script to load `/admin/posts` and capture a screenshot, which ran successfully and produced an artifact image (page rendered but middleware showed the Supabase env error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e86c1e0d88324827948b1ec91f3b3)