### PR TITLE
Add admin media uploads and markdown editor

### DIFF
--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deleteEvent, updateEvent } from "@/app/admin/events/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -74,15 +75,12 @@ export default async function EventDetailPage({
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Beskrivelse (Markdown)
-          <textarea
-            name="description"
-            rows={6}
-            defaultValue={event.description_md?.no ?? ""}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor
+          label="Beskrivelse (Markdown)"
+          name="description"
+          rows={8}
+          defaultValue={event.description_md?.no ?? ""}
+        />
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { createEvent } from "@/app/admin/events/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 
 export default function NewEventPage() {
   return (
@@ -39,14 +40,7 @@ export default function NewEventPage() {
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Beskrivelse (Markdown)
-          <textarea
-            name="description"
-            rows={6}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor label="Beskrivelse (Markdown)" name="description" rows={8} />
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { href: "/admin/events", label: "Arrangementer" },
   { href: "/admin/sermons", label: "Taler" },
   { href: "/admin/pages", label: "Sider" },
+  { href: "/admin/media", label: "Media" },
 ] satisfies { href: Route; label: string }[];
 
 export default function AdminLayout({

--- a/app/admin/media/actions.ts
+++ b/app/admin/media/actions.ts
@@ -75,7 +75,7 @@ export async function uploadMedia(formData: FormData) {
       alt: { no: alt },
       caption: caption ? { no: caption } : null,
     },
-    { onConflict: "path" }
+    { onConflict: "bucket,path" }
   );
 
   if (insertError) {

--- a/app/admin/media/actions.ts
+++ b/app/admin/media/actions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { createSupabaseAdminClient, createSupabaseServerClient } from "@/lib/supabase/server";
+
+const editorRoles = new Set(["admin", "editor"]);
+const allowedBuckets = new Set(["images", "podcasts"]);
+
+async function requireEditorUser() {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("User not authenticated.");
+  }
+
+  const adminClient = createSupabaseAdminClient();
+  const { data: profile, error } = await adminClient
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!profile || !editorRoles.has(profile.role)) {
+    throw new Error("User does not have permission to manage media.");
+  }
+
+  return { adminClient };
+}
+
+function resolveBucket(value: string | null) {
+  if (value && allowedBuckets.has(value)) {
+    return value;
+  }
+  return "images";
+}
+
+export async function uploadMedia(formData: FormData) {
+  const { adminClient } = await requireEditorUser();
+  const bucket = resolveBucket(formData.get("bucket")?.toString() ?? null);
+  const file = formData.get("file");
+
+  if (!(file instanceof File) || file.size === 0) {
+    throw new Error("No file selected.");
+  }
+
+  const rawPath = formData.get("path")?.toString().trim() ?? "";
+  const path = (rawPath || file.name).replace(/^\/+/, "");
+  const alt = formData.get("alt")?.toString().trim() ?? "";
+  const caption = formData.get("caption")?.toString().trim() ?? "";
+
+  const { error: uploadError } = await adminClient.storage
+    .from(bucket)
+    .upload(path, file, {
+      upsert: true,
+      contentType: file.type || undefined,
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message);
+  }
+
+  const { error: insertError } = await adminClient.from("media").upsert(
+    {
+      bucket,
+      path,
+      alt: { no: alt },
+      caption: caption ? { no: caption } : null,
+    },
+    { onConflict: "path" }
+  );
+
+  if (insertError) {
+    throw new Error(insertError.message);
+  }
+
+  revalidatePath("/admin/media");
+  redirect("/admin/media");
+}

--- a/app/admin/media/page.tsx
+++ b/app/admin/media/page.tsx
@@ -1,0 +1,182 @@
+import { uploadMedia } from "@/app/admin/media/actions";
+import { escapePostgrestText } from "@/lib/supabase/postgrest";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  return new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default async function MediaPage({
+  searchParams,
+}: {
+  searchParams?: { query?: string };
+}) {
+  const supabase = createSupabaseServerClient();
+  const query = searchParams?.query?.trim();
+  const escapedQuery = query ? escapePostgrestText(query) : null;
+  let request = supabase
+    .from("media")
+    .select("id, bucket, path, alt, caption, updated_at")
+    .order("updated_at", { ascending: false });
+  if (escapedQuery) {
+    request = request.or(
+      `path.ilike."%${escapedQuery}%",bucket.ilike."%${escapedQuery}%"`
+    );
+  }
+  const { data: media } = await request;
+
+  const mediaWithUrls =
+    media?.map((item) => {
+      const { data } = supabase.storage.from(item.bucket).getPublicUrl(item.path);
+      return { ...item, publicUrl: data.publicUrl };
+    }) ?? [];
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-100">Media</h2>
+        <p className="text-sm text-slate-400">
+          Last opp bilder eller MP3-filer, og registrer metadata for innholdet.
+        </p>
+      </div>
+
+      <form
+        action={uploadMedia}
+        className="grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/40 p-5"
+        encType="multipart/form-data"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
+            Fil
+            <input
+              type="file"
+              name="file"
+              required
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-sm text-slate-200 file:mr-4 file:rounded-full file:border-0 file:bg-white file:px-4 file:py-2 file:text-sm file:font-semibold file:text-slate-900"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-slate-200">
+            Bucket
+            <select
+              name="bucket"
+              defaultValue="images"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            >
+              <option value="images">images (bilder)</option>
+              <option value="podcasts">podcasts (MP3)</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
+            Lagringssti (valgfri)
+            <input
+              name="path"
+              placeholder="f.eks. nyheter/2024/cover.jpg"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-slate-200">
+            Alt-tekst (NO)
+            <input
+              name="alt"
+              placeholder="Beskriv bildet"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+
+        <label className="space-y-2 text-sm text-slate-200">
+          Bildetekst (NO)
+          <input
+            name="caption"
+            placeholder="Valgfri bildetekst"
+            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+          />
+        </label>
+
+        <button
+          type="submit"
+          className="w-fit rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900"
+        >
+          Last opp
+        </button>
+      </form>
+
+      <form className="flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-200">
+          Søk
+          <input
+            name="query"
+            defaultValue={query}
+            placeholder="Søk i bucket eller sti"
+            className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2 text-slate-100"
+          />
+        </label>
+        <button
+          type="submit"
+          className="mt-6 rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+        >
+          Filtrer
+        </button>
+      </form>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-800">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-900 text-left text-xs uppercase tracking-[0.2em] text-slate-500">
+            <tr>
+              <th className="px-4 py-3">Fil</th>
+              <th className="px-4 py-3">Bucket</th>
+              <th className="px-4 py-3">Alt-tekst</th>
+              <th className="px-4 py-3">Sist oppdatert</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {mediaWithUrls.map((item) => (
+              <tr key={item.id} className="bg-slate-950/40">
+                <td className="px-4 py-3">
+                  <div className="space-y-1">
+                    <p className="font-semibold text-slate-100">{item.path}</p>
+                    <a
+                      href={item.publicUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-xs text-brand-400 hover:text-brand-300"
+                    >
+                      Åpne fil
+                    </a>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-slate-400">{item.bucket}</td>
+                <td className="px-4 py-3 text-slate-400">
+                  {item.alt?.no || "-"}
+                </td>
+                <td className="px-4 py-3 text-slate-400">
+                  {formatDate(item.updated_at)}
+                </td>
+              </tr>
+            ))}
+            {!mediaWithUrls.length && (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-4 py-6 text-center text-sm text-slate-400"
+                >
+                  Ingen mediafiler ennå. Last opp ditt første bilde eller MP3.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -28,16 +28,23 @@ const cards = [
     href: "/admin/pages",
     key: "pages",
   },
+  {
+    title: "Media",
+    description: "Bilder og podcaster lagret i Supabase.",
+    href: "/admin/media",
+    key: "media",
+  },
 ] satisfies { title: string; description: string; href: Route; key: string }[];
 
 async function fetchCounts() {
   const supabase = createSupabaseServerClient();
 
-  const [posts, events, sermons, pages] = await Promise.all([
+  const [posts, events, sermons, pages, media] = await Promise.all([
     supabase.from("posts").select("id", { count: "exact", head: true }),
     supabase.from("events").select("id", { count: "exact", head: true }),
     supabase.from("sermons").select("id", { count: "exact", head: true }),
     supabase.from("pages").select("id", { count: "exact", head: true }),
+    supabase.from("media").select("id", { count: "exact", head: true }),
   ]);
 
   return {
@@ -45,6 +52,7 @@ async function fetchCounts() {
     events: events.count ?? 0,
     sermons: sermons.count ?? 0,
     pages: pages.count ?? 0,
+    media: media.count ?? 0,
   };
 }
 

--- a/app/admin/pages/[id]/page.tsx
+++ b/app/admin/pages/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deletePage, updatePage } from "@/app/admin/pages/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -69,15 +70,12 @@ export default async function PageDetailPage({
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Innhold (Markdown)
-          <textarea
-            name="content"
-            rows={10}
-            defaultValue={page.content_md?.no ?? ""}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor
+          label="Innhold (Markdown)"
+          name="content"
+          rows={12}
+          defaultValue={page.content_md?.no ?? ""}
+        />
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/pages/new/page.tsx
+++ b/app/admin/pages/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { createPage } from "@/app/admin/pages/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 
 export default function NewPage() {
   return (
@@ -37,14 +38,7 @@ export default function NewPage() {
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Innhold (Markdown)
-          <textarea
-            name="content"
-            rows={10}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor label="Innhold (Markdown)" name="content" rows={12} />
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deletePost, updatePost } from "@/app/admin/posts/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -79,15 +80,12 @@ export default async function PostDetailPage({
           />
         </label>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Innhold (Markdown)
-          <textarea
-            name="content"
-            rows={10}
-            defaultValue={post.content_md?.no ?? ""}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor
+          label="Innhold (Markdown)"
+          name="content"
+          rows={12}
+          defaultValue={post.content_md?.no ?? ""}
+        />
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { createPost } from "@/app/admin/posts/actions";
+import { MarkdownEditor } from "@/components/admin/markdown-editor";
 
 export default function NewPostPage() {
   return (
@@ -48,14 +49,7 @@ export default function NewPostPage() {
           />
         </label>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Innhold (Markdown)
-          <textarea
-            name="content"
-            rows={10}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <MarkdownEditor label="Innhold (Markdown)" name="content" rows={12} />
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="space-y-2 text-sm text-slate-200">

--- a/components/admin/markdown-editor.tsx
+++ b/components/admin/markdown-editor.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useId, useRef } from "react";
+
+type MarkdownEditorProps = {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  rows?: number;
+  required?: boolean;
+  helperText?: string;
+};
+
+const toolbarActions = [
+  { label: "Fet", before: "**", after: "**" },
+  { label: "Kursiv", before: "_", after: "_" },
+  { label: "Lenke", before: "[", after: "](https://)" },
+  { label: "Tittel", before: "## ", after: "" },
+  { label: "Liste", before: "- ", after: "" },
+] as const;
+
+export function MarkdownEditor({
+  label,
+  name,
+  defaultValue = "",
+  rows = 10,
+  required,
+  helperText,
+}: MarkdownEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const id = useId();
+
+  const applyFormatting = (before: string, after: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const selection = value.slice(start, end);
+    const nextValue = `${value.slice(0, start)}${before}${selection}${after}${value.slice(
+      end
+    )}`;
+
+    textarea.value = nextValue;
+    textarea.focus();
+    const cursor = start + before.length + selection.length + after.length;
+    textarea.setSelectionRange(cursor, cursor);
+  };
+
+  return (
+    <label className="space-y-2 text-sm text-slate-200" htmlFor={id}>
+      <span>{label}</span>
+      <div className="flex flex-wrap gap-2">
+        {toolbarActions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            onClick={() => applyFormatting(action.before, action.after)}
+            className="rounded-full border border-slate-800 px-3 py-1 text-xs text-slate-200 transition hover:border-slate-700 hover:bg-slate-900"
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+      <textarea
+        ref={textareaRef}
+        id={id}
+        name={name}
+        required={required}
+        rows={rows}
+        defaultValue={defaultValue}
+        className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+      />
+      <p className="text-xs text-slate-400">
+        {helperText ??
+          "Markdown støttes. Bruk **fet**, _kursiv_, [lenke](https://) og lister."}
+      </p>
+    </label>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight markdown editor for admin content forms and add a simple media manager so editors can upload and register images/MP3s in the CMS.

### Description
- Added a client-side `MarkdownEditor` component (`components/admin/markdown-editor.tsx`) and replaced plain `<textarea>`s with the editor in posts, pages and events admin forms.
- Implemented an admin media upload page (`app/admin/media/page.tsx`) with listing and public URL preview, and a server action (`app/admin/media/actions.ts`) that uploads files to Supabase storage and upserts metadata into the `media` table.
- Added role checks for editor/admin access to upload, limited allowed buckets to `images` and `podcasts`, and used `escapePostgrestText` for safe searching.
- Exposed the media section in the admin navigation and included media counts on the admin dashboard.

### Testing
- Started the dev server with `npm run dev` which compiled pages but runtime errors were reported due to missing Supabase project URL/Key environment variables, preventing a successful authenticated render of the admin media route.
- Ran a Playwright script to capture a screenshot of `http://127.0.0.1:3000/admin/media`; a screenshot artifact was produced even though the page returned 404/runtime errors because of missing Supabase env.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f66e17f888324a3c7a0d7ebb746c6)