### PR TITLE
Add public data access layer for posts, events, sermons and pages

### DIFF
--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -1,0 +1,58 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { LocalizedField } from "@/lib/data/localization";
+
+export type PublicEvent = {
+  id: string;
+  slug: string;
+  title: LocalizedField<string>;
+  description_md: LocalizedField<string>;
+  start_time: string;
+  end_time: string | null;
+  location: string | null;
+  published_at: string | null;
+};
+
+const publishedFilter = {
+  status: "published",
+  now: () => new Date().toISOString(),
+};
+
+export async function getUpcomingEvents(limit: number) {
+  const supabase = createSupabaseServerClient();
+  const now = publishedFilter.now();
+  const { data, error } = await supabase
+    .from("events")
+    .select(
+      "id, slug, title, description_md, start_time, end_time, location, published_at",
+    )
+    .eq("status", publishedFilter.status)
+    .lte("published_at", now)
+    .gte("start_time", now)
+    .order("start_time", { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as PublicEvent[];
+}
+
+export async function getEventBySlug(slug: string) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("events")
+    .select(
+      "id, slug, title, description_md, start_time, end_time, location, published_at",
+    )
+    .eq("slug", slug)
+    .eq("status", publishedFilter.status)
+    .lte("published_at", publishedFilter.now())
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as PublicEvent | null;
+}

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -1,0 +1,5 @@
+export * from "@/lib/data/events";
+export * from "@/lib/data/localization";
+export * from "@/lib/data/pages";
+export * from "@/lib/data/posts";
+export * from "@/lib/data/sermons";

--- a/lib/data/localization.ts
+++ b/lib/data/localization.ts
@@ -1,0 +1,15 @@
+export type Locale = "no" | "en" | (string & {});
+
+export type LocalizedField<T> = Record<string, T | null | undefined>;
+
+export function resolveLocalizedField<T>(
+  field: LocalizedField<T> | null | undefined,
+  locale: Locale,
+  fallbackLocale: Locale = "no",
+) {
+  if (!field) {
+    return null;
+  }
+
+  return field[locale] ?? field[fallbackLocale] ?? null;
+}

--- a/lib/data/pages.ts
+++ b/lib/data/pages.ts
@@ -1,0 +1,32 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { LocalizedField } from "@/lib/data/localization";
+
+export type PublicPage = {
+  id: string;
+  slug: string;
+  title: LocalizedField<string>;
+  content_md: LocalizedField<string>;
+  published_at: string | null;
+};
+
+const publishedFilter = {
+  status: "published",
+  now: () => new Date().toISOString(),
+};
+
+export async function getPageBySlug(slug: string) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("pages")
+    .select("id, slug, title, content_md, published_at")
+    .eq("slug", slug)
+    .eq("status", publishedFilter.status)
+    .lte("published_at", publishedFilter.now())
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as PublicPage | null;
+}

--- a/lib/data/posts.ts
+++ b/lib/data/posts.ts
@@ -1,0 +1,59 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { LocalizedField } from "@/lib/data/localization";
+
+export type PublicPost = {
+  id: string;
+  slug: string;
+  title: LocalizedField<string>;
+  excerpt: LocalizedField<string> | null;
+  cover_image_path: string | null;
+  published_at: string | null;
+};
+
+export type PublicPostDetail = {
+  id: string;
+  slug: string;
+  title: LocalizedField<string>;
+  content_md: LocalizedField<string>;
+  cover_image_path: string | null;
+  published_at: string | null;
+};
+
+const publishedFilter = {
+  status: "published",
+  now: () => new Date().toISOString(),
+};
+
+export async function getLatestPosts(limit: number) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("posts")
+    .select("id, slug, title, excerpt, cover_image_path, published_at")
+    .eq("status", publishedFilter.status)
+    .lte("published_at", publishedFilter.now())
+    .order("published_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as PublicPost[];
+}
+
+export async function getPostBySlug(slug: string) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("posts")
+    .select("id, slug, title, content_md, cover_image_path, published_at")
+    .eq("slug", slug)
+    .eq("status", publishedFilter.status)
+    .lte("published_at", publishedFilter.now())
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as PublicPostDetail | null;
+}

--- a/lib/data/sermons.ts
+++ b/lib/data/sermons.ts
@@ -1,0 +1,57 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export type PublicSermon = {
+  id: string;
+  slug: string;
+  title: string;
+  preacher: string | null;
+  bible_ref: string | null;
+  description: string | null;
+  published_at: string | null;
+  audio_path: string | null;
+  external_spotify_url: string | null;
+  external_apple_url: string | null;
+  duration_seconds: number | null;
+};
+
+const publishedFilter = {
+  now: () => new Date().toISOString(),
+};
+
+export async function getLatestSermons(limit: number) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("sermons")
+    .select(
+      "id, slug, title, preacher, bible_ref, description, published_at, audio_path, external_spotify_url, external_apple_url, duration_seconds",
+    )
+    .not("published_at", "is", null)
+    .lte("published_at", publishedFilter.now())
+    .order("published_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as PublicSermon[];
+}
+
+export async function getSermonBySlug(slug: string) {
+  const supabase = createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("sermons")
+    .select(
+      "id, slug, title, preacher, bible_ref, description, published_at, audio_path, external_spotify_url, external_apple_url, duration_seconds",
+    )
+    .eq("slug", slug)
+    .not("published_at", "is", null)
+    .lte("published_at", publishedFilter.now())
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as PublicSermon | null;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reusable data layer for the public-facing site to fetch posts, events, sermons and pages through the server Supabase client with consistent published filtering and minimal field selection.
- Support localized content lookup with a simple fallback to Norwegian (`no`) for localized JSONB fields.

### Description
- Added `lib/data/localization.ts` with `Locale`/`LocalizedField` types and `resolveLocalizedField(field, locale)` fallback logic to `no`.
- Implemented `lib/data/posts.ts` with `getLatestPosts(limit)` and `getPostBySlug(slug)` returning `PublicPost` / `PublicPostDetail` types and selecting only required fields via `createSupabaseServerClient` and published filters.
- Implemented `lib/data/events.ts` with `getUpcomingEvents(limit)` and `getEventBySlug(slug)` returning `PublicEvent` types and filtering on `status='published'` and `published_at <= now()` plus `start_time` for upcoming events.
- Implemented `lib/data/sermons.ts` with `getLatestSermons(limit)` and `getSermonBySlug(slug)` returning `PublicSermon` types and ensuring `published_at` is set and `<= now()`.
- Implemented `lib/data/pages.ts` with `getPageBySlug(slug)` returning `PublicPage` and filtering on `status='published'` and `published_at <= now()`.
- Added `lib/data/index.ts` to re-export the data modules for convenient imports.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696fbcb5f94c832484771ab3253027e9)