### PR TITLE
Default published timestamp for posts

### DIFF
--- a/app/admin/posts/actions.ts
+++ b/app/admin/posts/actions.ts
@@ -26,6 +26,14 @@ function normalizeDate(value: string | null) {
   return parsed.toISOString();
 }
 
+function normalizePublishedAt(status: string, value: string | null) {
+  const normalized = normalizeDate(value);
+  if (!normalized && status === "published") {
+    return new Date().toISOString();
+  }
+  return normalized;
+}
+
 async function requireEditorUser() {
   const supabase = createSupabaseServerClient();
   const {
@@ -62,7 +70,10 @@ export async function createPost(formData: FormData) {
   const excerpt = formData.get("excerpt")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
-  const publishedAt = normalizeDate(formData.get("published_at")?.toString() ?? null);
+  const publishedAt = normalizePublishedAt(
+    status,
+    formData.get("published_at")?.toString() ?? null,
+  );
   const coverImagePath = formData.get("cover_image_path")?.toString().trim() ?? "";
 
   const { data, error } = await adminClient
@@ -96,7 +107,10 @@ export async function updatePost(postId: string, formData: FormData) {
   const excerpt = formData.get("excerpt")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
-  const publishedAt = normalizeDate(formData.get("published_at")?.toString() ?? null);
+  const publishedAt = normalizePublishedAt(
+    status,
+    formData.get("published_at")?.toString() ?? null,
+  );
   const coverImagePath = formData.get("cover_image_path")?.toString().trim() ?? "";
 
   const { error } = await adminClient


### PR DESCRIPTION
### Motivation
- Ensure posts with `status` set to `published` but without an explicit `published_at` get a timestamp so they are returned by public queries that filter on publication time.

### Description
- Add `normalizePublishedAt(status, value)` which returns a parsed ISO date or sets `new Date().toISOString()` when `status === "published"` and the provided value is missing/invalid.
- Apply `normalizePublishedAt` in `createPost` and `updatePost` in `app/admin/posts/actions.ts` so inserted/updated rows always include an appropriate `published_at` value.
- Preserve existing `normalizeDate` and `normalizeStatus` behavior and otherwise keep create/update flows unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697256f159cc8324b35e05e1369e5fab)