### PR TITLE
Revalidate homepage after post updates

### DIFF
--- a/app/admin/posts/actions.ts
+++ b/app/admin/posts/actions.ts
@@ -96,6 +96,7 @@ export async function createPost(formData: FormData) {
   }
 
   revalidatePath("/admin/posts");
+  revalidatePath("/");
   redirect(`/admin/posts/${data.id}`);
 }
 
@@ -133,6 +134,7 @@ export async function updatePost(postId: string, formData: FormData) {
 
   revalidatePath("/admin/posts");
   revalidatePath(`/admin/posts/${postId}`);
+  revalidatePath("/");
 }
 
 export async function deletePost(postId: string) {
@@ -145,5 +147,6 @@ export async function deletePost(postId: string) {
   }
 
   revalidatePath("/admin/posts");
+  revalidatePath("/");
   redirect("/admin/posts");
 }


### PR DESCRIPTION
### Motivation
- Ensure newly created, updated or deleted posts become visible on the public homepage immediately by triggering a cache revalidation for the root path.

### Description
- Added `revalidatePath("/")` calls to `app/admin/posts/actions.ts` in `createPost`, `updatePost`, and `deletePost` so the public homepage is revalidated when posts change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697258c3c6e48324b4902989eec64b60)