### PR TITLE
Add news list and detail pages

### DIFF
--- a/app/(public)/nyheter/[slug]/page.tsx
+++ b/app/(public)/nyheter/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from "next/navigation";
+
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getPostBySlug, resolveLocalizedField } from "@/lib/data";
+
+export const revalidate = 1800;
+
+const locale = "no";
+const fallbackLocale = "en";
+
+const formatPublishedDate = (publishedAt: string) =>
+  new Intl.DateTimeFormat("nb-NO", { dateStyle: "long" }).format(new Date(publishedAt));
+
+type NewsDetailPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
+  const post = await getPostBySlug(params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const title =
+    resolveLocalizedField(post.title, locale, fallbackLocale) ?? "Nyhet";
+  const content =
+    resolveLocalizedField(post.content_md, locale, fallbackLocale) ??
+    "Innholdet er ikke tilgjengelig ennå.";
+  const publishedAt = post.published_at ? formatPublishedDate(post.published_at) : null;
+
+  return (
+    <article className="container-layout space-y-8 py-16">
+      <header className="space-y-3">
+        <Heading>{title}</Heading>
+        <BodyText>
+          {publishedAt ? `Publisert ${publishedAt}` : "Publiseringsdato kommer snart"}
+        </BodyText>
+      </header>
+
+      {post.cover_image_path ? (
+        <img
+          src={post.cover_image_path}
+          alt={title}
+          className="h-80 w-full rounded-2xl object-cover"
+        />
+      ) : null}
+
+      <div className="space-y-4">
+        <p className="whitespace-pre-line text-base leading-relaxed text-slate-700">
+          {content}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/app/(public)/nyheter/page.tsx
+++ b/app/(public)/nyheter/page.tsx
@@ -1,11 +1,69 @@
-export default function NewsPage() {
+import Link from "next/link";
+
+import { Card } from "@/components/ui/card";
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getPublishedPosts, resolveLocalizedField } from "@/lib/data";
+
+export const revalidate = 600;
+
+const locale = "no";
+const fallbackLocale = "en";
+
+export default async function NewsPage() {
+  const posts = await getPublishedPosts();
+
   return (
-    <section className="container-layout py-16">
-      <h1 className="text-3xl font-semibold text-slate-900">Nyheter</h1>
-      <p className="mt-4 max-w-2xl text-slate-600">
-        Siste nytt fra Bykirken kommer snart. Besøk denne siden for oppdateringer om
-        arrangementer, historier og kunngjøringer.
-      </p>
+    <section className="container-layout space-y-10 py-16">
+      <header className="space-y-3">
+        <Heading>Nyheter</Heading>
+        <BodyText>
+          Les de nyeste oppdateringene fra Bykirken. Artiklene er sortert med de nyeste
+          først.
+        </BodyText>
+      </header>
+
+      {posts.length ? (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {posts.map((post) => {
+            const title =
+              resolveLocalizedField(post.title, locale, fallbackLocale) ?? "Nyhet";
+            const excerpt =
+              resolveLocalizedField(post.excerpt, locale, fallbackLocale) ??
+              "Les mer om denne oppdateringen.";
+
+            return (
+              <Card key={post.id} className="flex h-full flex-col gap-4">
+                {post.cover_image_path ? (
+                  <img
+                    src={post.cover_image_path}
+                    alt={title}
+                    className="h-48 w-full rounded-xl object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="flex h-48 items-center justify-center rounded-xl bg-slate-100 text-sm text-slate-500">
+                    Ingen cover-bilde
+                  </div>
+                )}
+                <div className="flex flex-1 flex-col gap-3">
+                  <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+                  <BodyText>{excerpt}</BodyText>
+                </div>
+                <Link className="text-sm font-semibold text-brand-600" href={`/nyheter/${post.slug}`}>
+                  Les mer →
+                </Link>
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900">Ingen nyheter enda</h2>
+          <BodyText>
+            Vi jobber med nye historier og oppdateringer. Kom tilbake snart!
+          </BodyText>
+        </Card>
+      )}
     </section>
   );
 }

--- a/lib/data/posts.ts
+++ b/lib/data/posts.ts
@@ -41,6 +41,22 @@ export async function getLatestPosts(limit: number) {
   return (data ?? []) as PublicPost[];
 }
 
+export async function getPublishedPosts() {
+  const supabase = createSupabasePublicClient();
+  const { data, error } = await supabase
+    .from("posts")
+    .select("id, slug, title, excerpt, cover_image_path, published_at")
+    .eq("status", publishedFilter.status)
+    .lte("published_at", publishedFilter.now())
+    .order("published_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as PublicPost[];
+}
+
 export async function getPostBySlug(slug: string) {
   const supabase = createSupabasePublicClient();
   const { data, error } = await supabase


### PR DESCRIPTION
### Motivation

- Provide a public news listing and per-article detail view that show published posts (newest first) with language fallback and ISR.

### Description

- Add `getPublishedPosts` to `lib/data/posts.ts` to fetch all published posts sorted by `published_at`.
- Implement `/nyheter` list page at `app/(public)/nyheter/page.tsx` that calls `getPublishedPosts`, renders title, excerpt and cover image (or placeholder), uses `resolveLocalizedField` with `no`/`en` fallback, and sets `revalidate = 600`.
- Add article detail page at `app/(public)/nyheter/[slug]/page.tsx` that calls `getPostBySlug`, shows localized `content_md`, cover image and formatted `published_at`, and sets `revalidate = 1800`.
- Templates use simple `img` tags for covers, `Link` for navigation, and the existing UI components `Card`, `Heading`, and `BodyText`.

### Testing

- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` which compiled pages but requests failed at runtime because Supabase environment variables are missing; the app logged `Error: supabaseKey is required.`
- Attempted an automated Playwright navigation and screenshot of `/nyheter`, but the page returned a 500 due to the missing Supabase keys (screenshot artifact was produced for diagnostics).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69725a19c3ec832484edfe9614ba4b61)