### PR TITLE
Add calendar list and detail pages with ISR and locale fallback

### DIFF
--- a/app/(public)/kalender/[slug]/page.tsx
+++ b/app/(public)/kalender/[slug]/page.tsx
@@ -1,0 +1,67 @@
+import { notFound } from "next/navigation";
+
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getEventBySlug, resolveLocalizedField } from "@/lib/data";
+
+export const revalidate = 1800;
+
+const locale = "no";
+const fallbackLocale = "en";
+
+function formatEventDate(start: string, end: string | null) {
+  const startDate = new Date(start);
+  const endDate = end ? new Date(end) : null;
+  const dateFormatter = new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "full",
+  });
+  const timeFormatter = new Intl.DateTimeFormat("nb-NO", {
+    timeStyle: "short",
+  });
+  const dateLabel = dateFormatter.format(startDate);
+  const timeLabel = timeFormatter.format(startDate);
+
+  if (!endDate) {
+    return `${dateLabel} kl. ${timeLabel}`;
+  }
+
+  const endDateLabel = dateFormatter.format(endDate);
+  const endTimeLabel = timeFormatter.format(endDate);
+
+  if (dateLabel === endDateLabel) {
+    return `${dateLabel} kl. ${timeLabel}–${endTimeLabel}`;
+  }
+
+  return `${dateLabel} kl. ${timeLabel} – ${endDateLabel} kl. ${endTimeLabel}`;
+}
+
+type CalendarDetailPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export default async function CalendarDetailPage({ params }: CalendarDetailPageProps) {
+  const { slug } = await params;
+  const event = await getEventBySlug(slug);
+
+  if (!event) {
+    notFound();
+  }
+
+  const title = resolveLocalizedField(event.title, locale, fallbackLocale) ?? "Arrangement";
+  const description =
+    resolveLocalizedField(event.description_md, locale, fallbackLocale) ??
+    "Detaljer kommer snart.";
+
+  return (
+    <section className="container-layout space-y-8 py-16">
+      <header className="space-y-3">
+        <Heading>{title}</Heading>
+        <div className="space-y-1 text-sm text-slate-500">
+          <p>{formatEventDate(event.start_time, event.end_time)}</p>
+          {event.location ? <p>{event.location}</p> : null}
+        </div>
+      </header>
+
+      <BodyText className="max-w-3xl whitespace-pre-line">{description}</BodyText>
+    </section>
+  );
+}

--- a/app/(public)/kalender/page.tsx
+++ b/app/(public)/kalender/page.tsx
@@ -1,11 +1,90 @@
-export default function CalendarPage() {
+import Link from "next/link";
+
+import { Card } from "@/components/ui/card";
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getUpcomingEvents, resolveLocalizedField } from "@/lib/data";
+
+export const revalidate = 600;
+
+const locale = "no";
+const fallbackLocale = "en";
+
+function formatEventDate(start: string, end: string | null) {
+  const startDate = new Date(start);
+  const endDate = end ? new Date(end) : null;
+  const dateFormatter = new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "medium",
+  });
+  const timeFormatter = new Intl.DateTimeFormat("nb-NO", {
+    timeStyle: "short",
+  });
+  const dateLabel = dateFormatter.format(startDate);
+  const timeLabel = timeFormatter.format(startDate);
+
+  if (!endDate) {
+    return `${dateLabel} kl. ${timeLabel}`;
+  }
+
+  const endDateLabel = dateFormatter.format(endDate);
+  const endTimeLabel = timeFormatter.format(endDate);
+
+  if (dateLabel === endDateLabel) {
+    return `${dateLabel} kl. ${timeLabel}–${endTimeLabel}`;
+  }
+
+  return `${dateLabel} kl. ${timeLabel} – ${endDateLabel} kl. ${endTimeLabel}`;
+}
+
+export default async function CalendarPage() {
+  const events = await getUpcomingEvents(24);
+
   return (
-    <section className="container-layout py-16">
-      <h1 className="text-3xl font-semibold text-slate-900">Kalender</h1>
-      <p className="mt-4 max-w-2xl text-slate-600">
-        Vi samler kommende gudstjenester og aktiviteter her. Kalenderen oppdateres
-        fortløpende.
-      </p>
+    <section className="container-layout space-y-10 py-16">
+      <header className="space-y-3">
+        <Heading>Kalender</Heading>
+        <BodyText>
+          Se kommende arrangementer i Bykirken. Alle tider er oppdatert fortløpende og
+          sortert etter starttidspunkt.
+        </BodyText>
+      </header>
+
+      {events.length ? (
+        <div className="grid gap-6 md:grid-cols-2">
+          {events.map((event) => {
+            const title =
+              resolveLocalizedField(event.title, locale, fallbackLocale) ??
+              "Arrangement";
+            const description =
+              resolveLocalizedField(event.description_md, locale, fallbackLocale) ??
+              "Les mer om arrangementet.";
+
+            return (
+              <Card key={event.id} className="flex h-full flex-col gap-4">
+                <div className="space-y-2">
+                  <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+                  <p className="text-sm text-slate-500">
+                    {formatEventDate(event.start_time, event.end_time)}
+                  </p>
+                  {event.location ? (
+                    <p className="text-sm text-slate-500">{event.location}</p>
+                  ) : null}
+                </div>
+                <BodyText>{description}</BodyText>
+                <Link className="text-sm font-semibold text-brand-600" href={`/kalender/${event.slug}`}>
+                  Les mer →
+                </Link>
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900">Ingen kommende arrangementer</h2>
+          <BodyText>
+            Vi legger snart ut nye datoer. Ta gjerne kontakt hvis du lurer på noe.
+          </BodyText>
+        </Card>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the static calendar landing page with a dynamic upcoming events list so visitors can see scheduled events sorted by start time.
- Provide a dedicated event detail page that shows title, time, location and description for each event.
- Ensure titles and descriptions use language fallback and that the public pages are statically regenerated at reasonable intervals for freshness.

### Description
- Added `app/(public)/kalender/page.tsx` which fetches `getUpcomingEvents(24)`, displays events sorted by `start_time`, formats dates/times, uses `resolveLocalizedField` with `no` → `en` fallback, and sets `export const revalidate = 600`.
- Created `app/(public)/kalender/[slug]/page.tsx` which fetches `getEventBySlug(slug)`, renders title, formatted time, location and description with the same locale fallback, and sets `export const revalidate = 1800`.
- Both pages use the existing `lib/data` helpers and a small `formatEventDate` helper to render human-readable Norwegian date/time strings.
- Updated markup to use `Heading`, `BodyText`, `Card` components and added links from the list to detail pages.

### Testing
- Started the Next.js dev server via `npm run dev`, which compiled pages successfully but requests to `/kalender` returned 500 due to a missing `supabaseKey` configuration (failure for data fetch in dev environment).
- Ran a Playwright script to load `/kalender` and capture a screenshot, which produced an artifact at `browser:/tmp/codex_browser_invocations/.../artifacts/kalender.png` (succeeded despite the backend error being visible in the page).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69727c5842708324a34cd05621f8be40)