### PR TITLE
Add public podcast list and detail pages

### DIFF
--- a/app/(public)/podcast/[slug]/page.tsx
+++ b/app/(public)/podcast/[slug]/page.tsx
@@ -1,0 +1,92 @@
+import { notFound } from "next/navigation";
+
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getSermonBySlug } from "@/lib/data";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const revalidate = 1800;
+
+const formatPublishedDate = (publishedAt: string) =>
+  new Intl.DateTimeFormat("nb-NO", { dateStyle: "long" }).format(
+    new Date(publishedAt)
+  );
+
+type PodcastDetailPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export default async function PodcastDetailPage({ params }: PodcastDetailPageProps) {
+  const sermon = await getSermonBySlug(params.slug);
+
+  if (!sermon) {
+    notFound();
+  }
+
+  const publishedAt = sermon.published_at
+    ? formatPublishedDate(sermon.published_at)
+    : null;
+
+  const supabase = createSupabaseServerClient();
+  const audioUrl = sermon.audio_path
+    ? supabase.storage.from("podcasts").getPublicUrl(sermon.audio_path).data.publicUrl
+    : null;
+
+  return (
+    <section className="container-layout space-y-10 py-16">
+      <header className="space-y-3">
+        <Heading>{sermon.title}</Heading>
+        <div className="space-y-1 text-sm text-slate-500">
+          <p>{sermon.preacher ?? "Ukjent taler"}</p>
+          <p>
+            {publishedAt ? `Publisert ${publishedAt}` : "Publiseringsdato kommer snart"}
+          </p>
+          {sermon.bible_ref ? <p>{sermon.bible_ref}</p> : null}
+        </div>
+      </header>
+
+      {sermon.description ? (
+        <BodyText className="max-w-3xl whitespace-pre-line">
+          {sermon.description}
+        </BodyText>
+      ) : null}
+
+      <div className="space-y-4">
+        {audioUrl ? (
+          <audio controls className="w-full">
+            <source src={audioUrl} type="audio/mpeg" />
+            Nettleseren din støtter ikke avspilling av lyd.
+          </audio>
+        ) : (
+          <BodyText>Lydfilen er ikke tilgjengelig ennå.</BodyText>
+        )}
+
+        {(sermon.external_spotify_url || sermon.external_apple_url) && (
+          <div className="flex flex-wrap gap-3 text-sm font-semibold">
+            {sermon.external_spotify_url ? (
+              <a
+                href={sermon.external_spotify_url}
+                className="rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Lytt i Spotify
+              </a>
+            ) : null}
+            {sermon.external_apple_url ? (
+              <a
+                href={sermon.external_apple_url}
+                className="rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Lytt i Apple Podcasts
+              </a>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(public)/podcast/page.tsx
+++ b/app/(public)/podcast/page.tsx
@@ -1,10 +1,71 @@
-export default function PodcastPage() {
+import Link from "next/link";
+
+import { Card } from "@/components/ui/card";
+import { BodyText, Heading } from "@/components/ui/typography";
+import { getLatestSermons } from "@/lib/data";
+
+export const revalidate = 600;
+
+const formatPublishedDate = (publishedAt: string) =>
+  new Intl.DateTimeFormat("nb-NO", { dateStyle: "medium" }).format(
+    new Date(publishedAt)
+  );
+
+export default async function PodcastPage() {
+  const sermons = await getLatestSermons(24);
+
   return (
-    <section className="container-layout py-16">
-      <h1 className="text-3xl font-semibold text-slate-900">Podcast</h1>
-      <p className="mt-4 max-w-2xl text-slate-600">
-        Snart finner du de nyeste episodene våre her, med undervisning og samtaler.
-      </p>
+    <section className="container-layout space-y-10 py-16">
+      <header className="space-y-3">
+        <Heading>Podcast</Heading>
+        <BodyText>
+          Lytt til de siste talene fra Bykirken. Finn hele biblioteket i Spotify
+          eller Apple Podcasts.
+        </BodyText>
+      </header>
+
+      {sermons.length ? (
+        <div className="grid gap-6 md:grid-cols-2">
+          {sermons.map((sermon) => {
+            const publishedAt = sermon.published_at
+              ? formatPublishedDate(sermon.published_at)
+              : null;
+
+            return (
+              <Card key={sermon.id} className="flex h-full flex-col gap-4">
+                <div className="space-y-2">
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    {sermon.title}
+                  </h2>
+                  <div className="text-sm text-slate-500">
+                    <p>{sermon.preacher ?? "Ukjent taler"}</p>
+                    <p>
+                      {publishedAt
+                        ? `Publisert ${publishedAt}`
+                        : "Publiseres snart"}
+                    </p>
+                  </div>
+                </div>
+                <Link
+                  className="text-sm font-semibold text-brand-600"
+                  href={`/podcast/${sermon.slug}`}
+                >
+                  Åpne episode →
+                </Link>
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900">
+            Ingen episoder publisert ennå
+          </h2>
+          <BodyText>
+            Vi oppdaterer snart med nye taler. Kom tilbake litt senere.
+          </BodyText>
+        </Card>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a public podcast listing and per-episode detail pages so visitors can browse and play recent sermons. 
- Use Supabase Storage public URLs for serving MP3 files and expose external Spotify/Apple links for each episode. 
- Use ISR to keep pages reasonably fresh with `revalidate` set for list and detail pages. 

### Description
- Added a podcast list page at `app/(public)/podcast/page.tsx` that fetches `getLatestSermons(24)` and renders title, preacher and formatted `published_at` with `revalidate = 600`. 
- Added a podcast detail page at `app/(public)/podcast/[slug]/page.tsx` that fetches `getSermonBySlug`, shows metadata, an `<audio>` player using Supabase Storage public URL for `audio_path`, and optional Spotify/Apple links with `revalidate = 1800`. 
- Implemented locale-aware published date formatting and reused existing UI components (`Card`, `Heading`, `BodyText`). 
- Files changed/created: `app/(public)/podcast/page.tsx` (updated) and `app/(public)/podcast/[slug]/page.tsx` (new). 

### Testing
- Started the Next dev server with `npm run dev`, which launched successfully but requests for `/podcast` returned `500` due to missing Supabase project URL/Key required by the server client (expected when env vars are not set). 
- Ran a Playwright script to capture a screenshot of `/podcast`, which produced the artifact `artifacts/podcast-list.png` (script executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69727e386d688324bd222f136559b3f3)