### PR TITLE
Add shared markdown renderer for public pages

### DIFF
--- a/app/(public)/[pageSlug]/page.tsx
+++ b/app/(public)/[pageSlug]/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-
+import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { Heading } from "@/components/ui/typography";
 import { getPageBySlug, resolveLocalizedField } from "@/lib/data";
 
@@ -33,56 +32,7 @@ export default async function InfoPage({ params }: InfoPageProps) {
       <header>
         <Heading>{title}</Heading>
       </header>
-      <div className="space-y-5">
-        <ReactMarkdown
-          components={{
-            h1: ({ children }) => (
-              <h2 className="text-2xl font-semibold text-slate-900">
-                {children}
-              </h2>
-            ),
-            h2: ({ children }) => (
-              <h3 className="text-xl font-semibold text-slate-900">{children}</h3>
-            ),
-            h3: ({ children }) => (
-              <h4 className="text-lg font-semibold text-slate-900">{children}</h4>
-            ),
-            p: ({ children }) => (
-              <p className="text-base leading-relaxed text-slate-700">
-                {children}
-              </p>
-            ),
-            ul: ({ children }) => (
-              <ul className="list-disc space-y-2 pl-6 text-slate-700">
-                {children}
-              </ul>
-            ),
-            ol: ({ children }) => (
-              <ol className="list-decimal space-y-2 pl-6 text-slate-700">
-                {children}
-              </ol>
-            ),
-            li: ({ children }) => <li>{children}</li>,
-            a: ({ children, href }) => (
-              <a className="text-brand-600 underline" href={href}>
-                {children}
-              </a>
-            ),
-            blockquote: ({ children }) => (
-              <blockquote className="border-l-4 border-brand-200 pl-4 text-slate-600">
-                {children}
-              </blockquote>
-            ),
-            code: ({ children }) => (
-              <code className="rounded bg-slate-100 px-1 py-0.5 text-sm text-slate-800">
-                {children}
-              </code>
-            )
-          }}
-        >
-          {content}
-        </ReactMarkdown>
-      </div>
+      <MarkdownRenderer content={content} />
     </article>
   );
 }

--- a/app/(public)/kalender/[slug]/page.tsx
+++ b/app/(public)/kalender/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
-import { BodyText, Heading } from "@/components/ui/typography";
+import { MarkdownRenderer } from "@/components/markdown-renderer";
+import { Heading } from "@/components/ui/typography";
 import { getEventBySlug, resolveLocalizedField } from "@/lib/data";
 
 export const revalidate = 1800;
@@ -61,7 +62,7 @@ export default async function CalendarDetailPage({ params }: CalendarDetailPageP
         </div>
       </header>
 
-      <BodyText className="max-w-3xl whitespace-pre-line">{description}</BodyText>
+      <MarkdownRenderer content={description} className="max-w-3xl" />
     </section>
   );
 }

--- a/app/(public)/nyheter/[slug]/page.tsx
+++ b/app/(public)/nyheter/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 
+import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { BodyText, Heading } from "@/components/ui/typography";
 import { getPostBySlug, resolveLocalizedField } from "@/lib/data";
 
@@ -48,11 +49,7 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
         />
       ) : null}
 
-      <div className="space-y-4">
-        <p className="whitespace-pre-line text-base leading-relaxed text-slate-700">
-          {content}
-        </p>
-      </div>
+      <MarkdownRenderer content={content} className="space-y-4" />
     </article>
   );
 }

--- a/components/markdown-renderer.tsx
+++ b/components/markdown-renderer.tsx
@@ -1,0 +1,54 @@
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+
+type MarkdownRendererProps = {
+  content: string;
+  className?: string;
+};
+
+const markdownComponents: Components = {
+  h1: ({ children }) => (
+    <h2 className="text-2xl font-semibold text-slate-900">{children}</h2>
+  ),
+  h2: ({ children }) => (
+    <h3 className="text-xl font-semibold text-slate-900">{children}</h3>
+  ),
+  h3: ({ children }) => (
+    <h4 className="text-lg font-semibold text-slate-900">{children}</h4>
+  ),
+  p: ({ children }) => (
+    <p className="text-base leading-relaxed text-slate-700">{children}</p>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc space-y-2 pl-6 text-slate-700">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal space-y-2 pl-6 text-slate-700">{children}</ol>
+  ),
+  li: ({ children }) => <li>{children}</li>,
+  a: ({ children, href }) => (
+    <a className="text-brand-600 underline" href={href}>
+      {children}
+    </a>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-4 border-brand-200 pl-4 text-slate-600">
+      {children}
+    </blockquote>
+  ),
+  code: ({ children }) => (
+    <code className="rounded bg-slate-100 px-1 py-0.5 text-sm text-slate-800">
+      {children}
+    </code>
+  ),
+};
+
+export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+  const wrapperClassName = className ? `space-y-5 ${className}` : "space-y-5";
+
+  return (
+    <div className={wrapperClassName}>
+      <ReactMarkdown components={markdownComponents}>{content}</ReactMarkdown>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Centralize Markdown rendering for public-facing content (info pages, news, events) to keep styling consistent.
- Render Markdown safely by default without enabling raw HTML parsing.

### Description
- Add `components/markdown-renderer.tsx` which uses `react-markdown` and a set of safe, styled `components` to render Markdown.
- Replace inline `ReactMarkdown` / preformatted paragraph usage with the new `MarkdownRenderer` on `app/(public)/[pageSlug]/page.tsx`, `app/(public)/nyheter/[slug]/page.tsx`, and `app/(public)/kalender/[slug]/page.tsx`.
- Export `MarkdownRenderer({ content, className })` so pages can pass Markdown content and optional wrapper classes.

### Testing
- Ran `npm run dev` which compiled Next.js (middleware and app) but the running server returned a runtime error `supabaseKey is required` causing a `500` on `/` due to missing env config.
- Executed a Playwright script that attempted to visit `/` and produced a screenshot artifact at `artifacts/.../markdown-renderer-home.png`.
- No unit or integration tests were added or executed for the renderer in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697282dae300832492a0eac1ab69a6e1)