### PR TITLE
Add public 404 and metadata (generateMetadata + helper) for public pages

### DIFF
--- a/app/(public)/[pageSlug]/page.tsx
+++ b/app/(public)/[pageSlug]/page.tsx
@@ -1,7 +1,9 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { Heading } from "@/components/ui/typography";
 import { getPageBySlug, resolveLocalizedField } from "@/lib/data";
+import { toMetadataDescription } from "@/lib/utils/metadata";
 
 export const revalidate = 3600;
 
@@ -13,6 +15,35 @@ type InfoPageProps = {
     pageSlug: string;
   };
 };
+
+export async function generateMetadata({
+  params,
+}: InfoPageProps): Promise<Metadata> {
+  const page = await getPageBySlug(params.pageSlug);
+
+  if (!page) {
+    return {
+      title: "Side ikke funnet | Bykirken",
+      description: "Vi fant ikke siden du leter etter.",
+    };
+  }
+
+  const title =
+    resolveLocalizedField(page.title, locale, fallbackLocale) ?? "Infoside";
+  const descriptionSource = resolveLocalizedField(
+    page.content_md,
+    locale,
+    fallbackLocale,
+  );
+
+  return {
+    title: `${title} | Bykirken`,
+    description: toMetadataDescription(
+      descriptionSource,
+      "Informasjon fra Bykirken.",
+    ),
+  };
+}
 
 export default async function InfoPage({ params }: InfoPageProps) {
   const page = await getPageBySlug(params.pageSlug);

--- a/app/(public)/kalender/[slug]/page.tsx
+++ b/app/(public)/kalender/[slug]/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { Heading } from "@/components/ui/typography";
 import { getEventBySlug, resolveLocalizedField } from "@/lib/data";
+import { toMetadataDescription } from "@/lib/utils/metadata";
 
 export const revalidate = 1800;
 
@@ -38,6 +40,36 @@ function formatEventDate(start: string, end: string | null) {
 type CalendarDetailPageProps = {
   params: Promise<{ slug: string }>;
 };
+
+export async function generateMetadata({
+  params,
+}: CalendarDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const event = await getEventBySlug(slug);
+
+  if (!event) {
+    return {
+      title: "Arrangement ikke funnet | Bykirken",
+      description: "Vi fant ikke arrangementet du lette etter.",
+    };
+  }
+
+  const title =
+    resolveLocalizedField(event.title, locale, fallbackLocale) ?? "Arrangement";
+  const descriptionSource = resolveLocalizedField(
+    event.description_md,
+    locale,
+    fallbackLocale,
+  );
+
+  return {
+    title: `${title} | Bykirken`,
+    description: toMetadataDescription(
+      descriptionSource,
+      "Detaljer om arrangementer i Bykirken.",
+    ),
+  };
+}
 
 export default async function CalendarDetailPage({ params }: CalendarDetailPageProps) {
   const { slug } = await params;

--- a/app/(public)/kalender/page.tsx
+++ b/app/(public)/kalender/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Card } from "@/components/ui/card";
@@ -8,6 +9,13 @@ export const revalidate = 600;
 
 const locale = "no";
 const fallbackLocale = "en";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Kalender | Bykirken",
+    description: "Se kommende arrangementer og samlinger i Bykirken.",
+  };
+}
 
 function formatEventDate(start: string, end: string | null) {
   const startDate = new Date(start);

--- a/app/(public)/nyheter/[slug]/page.tsx
+++ b/app/(public)/nyheter/[slug]/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { BodyText, Heading } from "@/components/ui/typography";
 import { getPostBySlug, resolveLocalizedField } from "@/lib/data";
+import { toMetadataDescription } from "@/lib/utils/metadata";
 
 export const revalidate = 1800;
 
@@ -17,6 +19,35 @@ type NewsDetailPageProps = {
     slug: string;
   };
 };
+
+export async function generateMetadata({
+  params,
+}: NewsDetailPageProps): Promise<Metadata> {
+  const post = await getPostBySlug(params.slug);
+
+  if (!post) {
+    return {
+      title: "Nyhet ikke funnet | Bykirken",
+      description: "Vi fant ikke nyheten du lette etter.",
+    };
+  }
+
+  const title =
+    resolveLocalizedField(post.title, locale, fallbackLocale) ?? "Nyhet";
+  const descriptionSource = resolveLocalizedField(
+    post.content_md,
+    locale,
+    fallbackLocale,
+  );
+
+  return {
+    title: `${title} | Bykirken`,
+    description: toMetadataDescription(
+      descriptionSource,
+      "Les siste nyheter og oppdateringer fra Bykirken.",
+    ),
+  };
+}
 
 export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   const post = await getPostBySlug(params.slug);

--- a/app/(public)/nyheter/page.tsx
+++ b/app/(public)/nyheter/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Card } from "@/components/ui/card";
@@ -8,6 +9,13 @@ export const revalidate = 600;
 
 const locale = "no";
 const fallbackLocale = "en";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Nyheter | Bykirken",
+    description: "Les de nyeste oppdateringene og historiene fra Bykirken.",
+  };
+}
 
 export default async function NewsPage() {
   const posts = await getPublishedPosts();

--- a/app/(public)/podcast/[slug]/page.tsx
+++ b/app/(public)/podcast/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { BodyText, Heading } from "@/components/ui/typography";
@@ -16,6 +17,24 @@ type PodcastDetailPageProps = {
     slug: string;
   };
 };
+
+export async function generateMetadata({
+  params,
+}: PodcastDetailPageProps): Promise<Metadata> {
+  const sermon = await getSermonBySlug(params.slug);
+
+  if (!sermon) {
+    return {
+      title: "Episode ikke funnet | Bykirken",
+      description: "Vi fant ikke podcast-episoden du lette etter.",
+    };
+  }
+
+  return {
+    title: `${sermon.title} | Bykirken`,
+    description: sermon.description ?? "Lytt til en tale fra Bykirken.",
+  };
+}
 
 export default async function PodcastDetailPage({ params }: PodcastDetailPageProps) {
   const sermon = await getSermonBySlug(params.slug);

--- a/app/(public)/podcast/page.tsx
+++ b/app/(public)/podcast/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Card } from "@/components/ui/card";
@@ -10,6 +11,13 @@ const formatPublishedDate = (publishedAt: string) =>
   new Intl.DateTimeFormat("nb-NO", { dateStyle: "medium" }).format(
     new Date(publishedAt)
   );
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Podcast | Bykirken",
+    description: "Lytt til de siste talene fra Bykirken.",
+  };
+}
 
 export default async function PodcastPage() {
   const sermons = await getLatestSermons(24);

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+import { BodyText, Heading } from "@/components/ui/typography";
+
+export default function NotFoundPage() {
+  return (
+    <section className="container-layout flex min-h-[60vh] flex-col justify-center gap-4 py-16">
+      <Heading>Beklager, siden ble ikke funnet</Heading>
+      <BodyText>
+        Vi finner ikke siden du leter etter. Sjekk gjerne adressen eller gå tilbake
+        til forsiden.
+      </BodyText>
+      <div>
+        <Link className="text-sm font-semibold text-brand-600" href="/">
+          Gå til forsiden →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/lib/utils/metadata.ts
+++ b/lib/utils/metadata.ts
@@ -1,0 +1,18 @@
+export function toMetadataDescription(
+  value: string | null | undefined,
+  fallback: string,
+) {
+  if (!value) {
+    return fallback;
+  }
+
+  const withoutLinks = value.replace(/\[(.*?)\]\(.*?\)/g, "$1");
+  const cleaned = withoutLinks.replace(/[#>*_`]/g, "");
+  const normalized = cleaned.replace(/\s+/g, " ").trim();
+
+  if (!normalized) {
+    return fallback;
+  }
+
+  return normalized.slice(0, 160);
+}


### PR DESCRIPTION
### Motivation

- Provide a clear public-facing 404 page with a link back to the homepage so visitors get a friendly error screen.
- Improve SEO and social metadata for public sections (news, calendar, podcast, info pages) by using `generateMetadata` where appropriate.
- Ensure metadata descriptions use the correct locale with a fallback and are cleaned/trimmed to safe lengths.

### Description

- Added a public 404 page at `app/not-found.tsx` that displays a message and a link to the homepage.
- Added `lib/utils/metadata.ts` with `toMetadataDescription` to sanitize and trim markdown/plain text into a short description.
- Implemented `generateMetadata` on public index and detail pages for news, calendar, podcast, and dynamic info pages under `app/(public)/*`, using `resolveLocalizedField` with `locale`/`fallbackLocale` and `toMetadataDescription` for descriptions.
- Updated detail pages to return language-aware titles and fallback descriptions, and kept existing page rendering behavior unchanged.

### Testing

- Started the local dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` to validate compilation, but the build failed due to a missing `react-markdown` dependency (module-not-found), so the server did not fully compile.
- Attempted to capture the 404 page with Playwright, but the script timed out / failed because the dev server did not complete compilation.
- No automated tests passed in this run due to the missing dependency and compile error; code changes were committed (`Add metadata and public 404 page`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697284a011a48324b875462a9f1e8475)