### PR TITLE
Fix public data queries and homepage navigation

### DIFF
--- a/app/(public)/kalender/[slug]/page.tsx
+++ b/app/(public)/kalender/[slug]/page.tsx
@@ -38,14 +38,15 @@ function formatEventDate(start: string, end: string | null) {
 }
 
 type CalendarDetailPageProps = {
-  params: Promise<{ slug: string }>;
+  params: {
+    slug: string;
+  };
 };
 
 export async function generateMetadata({
   params,
 }: CalendarDetailPageProps): Promise<Metadata> {
-  const { slug } = await params;
-  const event = await getEventBySlug(slug);
+  const event = await getEventBySlug(params.slug);
 
   if (!event) {
     return {
@@ -72,8 +73,7 @@ export async function generateMetadata({
 }
 
 export default async function CalendarDetailPage({ params }: CalendarDetailPageProps) {
-  const { slug } = await params;
-  const event = await getEventBySlug(slug);
+  const event = await getEventBySlug(params.slug);
 
   if (!event) {
     notFound();

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -2,7 +2,6 @@
 import type { Route } from "next";
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { BodyText, Heading, Subheading } from "@/components/ui/typography";
 import {
@@ -20,6 +19,14 @@ const quickLinks: Array<{ title: string; description: string; href: Route }> = [
 ];
 
 const locale = "no";
+
+const buttonBaseClasses =
+  "inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold transition";
+const buttonVariants = {
+  primary: "bg-brand-600 text-white hover:bg-brand-700",
+  secondary: "bg-white text-slate-900 border border-slate-200 hover:bg-slate-50",
+  ghost: "text-slate-700 hover:bg-slate-100",
+};
 
 const formatEventDate = (date: string) =>
   new Intl.DateTimeFormat("nb-NO", {
@@ -57,8 +64,18 @@ export default async function HomePage() {
               {nextEventDescription}
             </BodyText>
             <div className="flex flex-wrap gap-3">
-              <Button>Se kalender</Button>
-              <Button variant="secondary">Bli med i fellesskapet</Button>
+              <Link
+                className={`${buttonBaseClasses} ${buttonVariants.primary}`}
+                href="/kalender"
+              >
+                Se kalender
+              </Link>
+              <Link
+                className={`${buttonBaseClasses} ${buttonVariants.secondary}`}
+                href="/kontakt"
+              >
+                Bli med i fellesskapet
+              </Link>
             </div>
           </div>
           <Card className="space-y-4">
@@ -69,7 +86,12 @@ export default async function HomePage() {
               <p className="text-sm uppercase tracking-[0.2em] text-slate-400">Denne uken</p>
               <Subheading>{nextEventTitle}</Subheading>
               <BodyText>{nextEventDate ? `${nextEventDate} · ${nextEventLocation}` : "Ingen publiserte arrangementer enda."}</BodyText>
-              <Button variant="ghost">Se kalender</Button>
+              <Link
+                className={`${buttonBaseClasses} ${buttonVariants.ghost}`}
+                href="/kalender"
+              >
+                Se kalender
+              </Link>
             </div>
           </Card>
         </div>
@@ -138,7 +160,12 @@ export default async function HomePage() {
                     </div>
                     <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
                     <BodyText>{excerpt}</BodyText>
-                    <Button variant="ghost">Les mer</Button>
+                    <Link
+                      className={`${buttonBaseClasses} ${buttonVariants.ghost}`}
+                      href={`/nyheter/${post.slug}`}
+                    >
+                      Les mer
+                    </Link>
                   </Card>
                 );
               })

--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -1,4 +1,4 @@
-import { createSupabasePublicClient } from "@/lib/supabase/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { LocalizedField } from "@/lib/data/localization";
 
 export type PublicEvent = {
@@ -18,7 +18,7 @@ const publishedFilter = {
 };
 
 export async function getUpcomingEvents(limit: number) {
-  const supabase = createSupabasePublicClient();
+  const supabase = createSupabaseServerClient();
   const now = publishedFilter.now();
   const { data, error } = await supabase
     .from("events")
@@ -39,7 +39,7 @@ export async function getUpcomingEvents(limit: number) {
 }
 
 export async function getEventBySlug(slug: string) {
-  const supabase = createSupabasePublicClient();
+  const supabase = createSupabaseServerClient();
   const { data, error } = await supabase
     .from("events")
     .select(

--- a/lib/data/posts.ts
+++ b/lib/data/posts.ts
@@ -1,4 +1,4 @@
-import { createSupabasePublicClient } from "@/lib/supabase/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { LocalizedField } from "@/lib/data/localization";
 
 export type PublicPost = {
@@ -25,7 +25,7 @@ const publishedFilter = {
 };
 
 export async function getLatestPosts(limit: number) {
-  const supabase = createSupabasePublicClient();
+  const supabase = createSupabaseServerClient();
   const { data, error } = await supabase
     .from("posts")
     .select("id, slug, title, excerpt, cover_image_path, published_at")
@@ -42,7 +42,7 @@ export async function getLatestPosts(limit: number) {
 }
 
 export async function getPublishedPosts() {
-  const supabase = createSupabasePublicClient();
+  const supabase = createSupabaseServerClient();
   const { data, error } = await supabase
     .from("posts")
     .select("id, slug, title, excerpt, cover_image_path, published_at")
@@ -58,7 +58,7 @@ export async function getPublishedPosts() {
 }
 
 export async function getPostBySlug(slug: string) {
-  const supabase = createSupabasePublicClient();
+  const supabase = createSupabaseServerClient();
   const { data, error } = await supabase
     .from("posts")
     .select("id, slug, title, content_md, cover_image_path, published_at")


### PR DESCRIPTION
### Motivation

- Ensure public-facing data queries run on the server-side Supabase client to satisfy RLS and avoid client-only auth issues.
- Make homepage CTAs and news cards navigable links that work from server components and share consistent button styling.
- Fix route param typing in the calendar detail page to avoid awaiting a promise-typed `params` object.

### Description

- Switched `createSupabasePublicClient` to `createSupabaseServerClient` for posts and events queries in `lib/data/posts.ts` and `lib/data/events.ts` so public read queries use the server client while keeping the published filters intact.  
- Reworked the homepage `app/(public)/page.tsx` to remove the client-only `Button` usage, added `buttonBaseClasses` and `buttonVariants` constants, and replaced CTAs and news card actions with `Link` elements styled as buttons.  
- Updated calendar detail props/usage in `app/(public)/kalender/[slug]/page.tsx` to use `params: { slug: string }` and call `getEventBySlug(params.slug)` directly instead of awaiting a promise-shaped `params`.  
- Files changed: `lib/data/posts.ts`, `lib/data/events.ts`, `app/(public)/page.tsx`, `app/(public)/kalender/[slug]/page.tsx`.

### Testing

- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which began compiling but requests failed with a 500 because Supabase env vars (`NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY`) were not set.  
- Ran an automated Playwright script to capture the homepage, which produced a screenshot artifact but the page returned 500 due to the missing Supabase credentials, so end-to-end render verification is blocked by environment configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697286da3754832497fa0d10bd356407)