### PR TITLE
Add unique constraint for media bucket/path upserts

### DIFF
--- a/db/migrations/0002_media_bucket_path_unique.sql
+++ b/db/migrations/0002_media_bucket_path_unique.sql
@@ -1,0 +1,5 @@
+alter table media
+  drop constraint if exists media_path_key;
+
+alter table media
+  add constraint media_bucket_path_key unique (bucket, path);


### PR DESCRIPTION
### Motivation
- Image uploads failed with "there is no unique or exclusion constraint matching the ON CONFLICT specification" because `uploadMedia` uses `upsert` with `onConflict: "bucket,path"` and the database had only a single-column unique on `path`. 
- Ensure `ON CONFLICT (bucket,path)` has a matching constraint so uploads and upserts succeed without errors.

### Description
- Add migration `db/migrations/0002_media_bucket_path_unique.sql` that drops the old `media_path_key` constraint and adds `media_bucket_path_key unique (bucket, path)`.
- This migration makes the `upsert` call in `app/admin/media/actions.ts` (which uses `onConflict: "bucket,path"`) match an actual unique constraint.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69728d7198108324b19bdaf820f9bdd7)