### PR TITLE
Allow public content when `published_at` is unset

### DIFF
--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -20,13 +20,14 @@ const publishedFilter = {
 export async function getUpcomingEvents(limit: number) {
   const supabase = createSupabaseServerClient();
   const now = publishedFilter.now();
+  const publishedAtFilter = `published_at.is.null,published_at.lte.${now}`;
   const { data, error } = await supabase
     .from("events")
     .select(
       "id, slug, title, description_md, start_time, end_time, location, published_at",
     )
     .eq("status", publishedFilter.status)
-    .lte("published_at", now)
+    .or(publishedAtFilter)
     .gte("start_time", now)
     .order("start_time", { ascending: true })
     .limit(limit);
@@ -40,6 +41,7 @@ export async function getUpcomingEvents(limit: number) {
 
 export async function getEventBySlug(slug: string) {
   const supabase = createSupabaseServerClient();
+  const now = publishedFilter.now();
   const { data, error } = await supabase
     .from("events")
     .select(
@@ -47,7 +49,7 @@ export async function getEventBySlug(slug: string) {
     )
     .eq("slug", slug)
     .eq("status", publishedFilter.status)
-    .lte("published_at", publishedFilter.now())
+    .or(`published_at.is.null,published_at.lte.${now}`)
     .maybeSingle();
 
   if (error) {

--- a/lib/data/pages.ts
+++ b/lib/data/pages.ts
@@ -16,12 +16,13 @@ const publishedFilter = {
 
 export async function getPageBySlug(slug: string) {
   const supabase = createSupabaseServerClient();
+  const now = publishedFilter.now();
   const { data, error } = await supabase
     .from("pages")
     .select("id, slug, title, content_md, published_at")
     .eq("slug", slug)
     .eq("status", publishedFilter.status)
-    .lte("published_at", publishedFilter.now())
+    .or(`published_at.is.null,published_at.lte.${now}`)
     .maybeSingle();
 
   if (error) {

--- a/lib/data/sermons.ts
+++ b/lib/data/sermons.ts
@@ -20,13 +20,13 @@ const publishedFilter = {
 
 export async function getLatestSermons(limit: number) {
   const supabase = createSupabaseServerClient();
+  const now = publishedFilter.now();
   const { data, error } = await supabase
     .from("sermons")
     .select(
       "id, slug, title, preacher, bible_ref, description, published_at, audio_path, external_spotify_url, external_apple_url, duration_seconds",
     )
-    .not("published_at", "is", null)
-    .lte("published_at", publishedFilter.now())
+    .or(`published_at.is.null,published_at.lte.${now}`)
     .order("published_at", { ascending: false })
     .limit(limit);
 
@@ -39,14 +39,14 @@ export async function getLatestSermons(limit: number) {
 
 export async function getSermonBySlug(slug: string) {
   const supabase = createSupabaseServerClient();
+  const now = publishedFilter.now();
   const { data, error } = await supabase
     .from("sermons")
     .select(
       "id, slug, title, preacher, bible_ref, description, published_at, audio_path, external_spotify_url, external_apple_url, duration_seconds",
     )
     .eq("slug", slug)
-    .not("published_at", "is", null)
-    .lte("published_at", publishedFilter.now())
+    .or(`published_at.is.null,published_at.lte.${now}`)
     .maybeSingle();
 
   if (error) {


### PR DESCRIPTION
### Motivation
- Event, page and sermon records that had `published_at` unset were not returned by public queries even though they exist in the DB, causing calendar, podcast and info pages to be hidden.
- Use a single timestamp per request to avoid inconsistent published-time comparisons when composing `OR` filters.

### Description
- Update `lib/data/events.ts` to allow `published_at` to be null by adding a `publishedAtFilter` and replacing `.lte("published_at", ...)` with `.or(...)` and reuse a single `now` value in queries.
- Update `lib/data/pages.ts` to replace `.lte("published_at", ...)` with `.or(`published_at.is.null,published_at.lte.${now}`)` and reuse `now` in `getPageBySlug`.
- Update `lib/data/sermons.ts` to replace `.not("published_at","is",null).lte(...)` with `.or(`published_at.is.null,published_at.lte.${now}`)` in `getLatestSermons` and `getSermonBySlug`, and reuse `now`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972933daff88324abc1e4a9bc8b98e6)