### PR TITLE
Add legacy podcast media proxy and RSS feed

### DIFF
--- a/app/images/stories/media/[filename]/route.ts
+++ b/app/images/stories/media/[filename]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { createSupabasePublicClient } from "@/lib/supabase/server";
+
+type RouteParams = {
+  params: {
+    filename: string;
+  };
+};
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const filename = params.filename;
+  const supabase = createSupabasePublicClient();
+
+  const { data, error } = await supabase
+    .from("sermons")
+    .select("audio_path")
+    .eq("filename", filename)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to load sermon." }, { status: 500 });
+  }
+
+  if (!data?.audio_path) {
+    return NextResponse.json({ error: "Sermon not found." }, { status: 404 });
+  }
+
+  const { data: audioData } = supabase.storage
+    .from("podcasts")
+    .getPublicUrl(data.audio_path);
+
+  if (!audioData.publicUrl) {
+    return NextResponse.json({ error: "Audio not found." }, { status: 404 });
+  }
+
+  return NextResponse.redirect(audioData.publicUrl, { status: 307 });
+}

--- a/app/images/stories/media/bykirken.xml/route.ts
+++ b/app/images/stories/media/bykirken.xml/route.ts
@@ -1,0 +1,93 @@
+import { createSupabasePublicClient } from "@/lib/supabase/server";
+
+const SITE_URL = "https://www.bykirken.no";
+const LEGACY_MEDIA_URL = `${SITE_URL}/images/stories/media`;
+
+type SermonRecord = {
+  filename: string;
+  published_at: string | null;
+  file_size: number | null;
+  duration_seconds: number | null;
+  title: string | null;
+  description: string | null;
+};
+
+const publishedFilter = {
+  now: () => new Date().toISOString(),
+};
+
+const formatRssDate = (value: string) => new Date(value).toUTCString();
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+export async function GET() {
+  const supabase = createSupabasePublicClient();
+  const now = publishedFilter.now();
+  const { data, error } = await supabase
+    .from("sermons")
+    .select(
+      "filename, published_at, file_size, duration_seconds, title, description",
+    )
+    .or(`published_at.is.null,published_at.lte.${now}`)
+    .order("published_at", { ascending: false });
+
+  if (error) {
+    return new Response("Failed to load sermons.", { status: 500 });
+  }
+
+  const items = (data ?? [])
+    .filter(
+      (sermon): sermon is SermonRecord =>
+        Boolean(sermon.filename) && typeof sermon.filename === "string",
+    )
+    .map((sermon) => {
+      const title = escapeXml(sermon.title ?? "Tale fra Bykirken");
+      const description = escapeXml(sermon.description ?? "");
+      const enclosureUrl = `${LEGACY_MEDIA_URL}/${sermon.filename}`;
+      const publishedAt = sermon.published_at
+        ? formatRssDate(sermon.published_at)
+        : null;
+      const length = sermon.file_size ?? 0;
+      const duration = sermon.duration_seconds ?? 0;
+
+      return [
+        "    <item>",
+        `      <title>${title}</title>`,
+        `      <description>${description}</description>`,
+        `      <link>${enclosureUrl}</link>`,
+        publishedAt ? `      <pubDate>${publishedAt}</pubDate>` : null,
+        `      <enclosure url="${enclosureUrl}" length="${length}" type="audio/mpeg" />`,
+        `      <itunes:duration>${duration}</itunes:duration>`,
+        "    </item>",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n");
+
+  const rss = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">',
+    "  <channel>",
+    "    <title>Bykirken Podcast</title>",
+    `    <link>${SITE_URL}</link>`,
+    "    <description>Podcast med taler fra Bykirken.</description>",
+    `    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
+    items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\n");
+
+  return new Response(rss, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,14 @@ const nextConfig = {
   experimental: {
     typedRoutes: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: "/images/stories/media/:filename",
+        destination: "/images/stories/media/:filename",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- Restore compatibility for legacy MP3 URLs so old links under `/images/stories/media/:filename` continue to work and can be logged or have fallbacks.
- Provide the legacy RSS feed at `/images/stories/media/bykirken.xml` so existing subscribers and directories keep receiving the podcast feed.

### Description
- Add a legacy rewrite in `next.config.mjs` that routes requests for `/images/stories/media/:filename` into the app so the handler can proxy or log requests.
- Implement `app/images/stories/media/[filename]/route.ts` which looks up `sermons` by `filename` via `createSupabasePublicClient()`, gets the Supabase storage public URL for the sermon `audio_path`, and returns a `307` redirect or `404/500` JSON errors.
- Implement `app/images/stories/media/bykirken.xml/route.ts` which queries `sermons` (filtered by `published_at`), escapes XML, formats dates, and emits an RSS XML feed with `<enclosure>` entries that point to the legacy URL `https://www.bykirken.no/images/stories/media/${filename}` and include `file_size` and `duration_seconds` as `length` and `<itunes:duration>`.
- Ensure only records with a string `filename` are included and return proper `Content-Type: application/rss+xml; charset=utf-8` for the feed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972986b4a908324bb22f0578fcefda6)