### PR TITLE
Add language toggle, locale normalization, and EN fields for admin editors

### DIFF
--- a/app/(public)/[pageSlug]/page.tsx
+++ b/app/(public)/[pageSlug]/page.tsx
@@ -1,23 +1,25 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { Heading } from "@/components/ui/typography";
-import { getPageBySlug, resolveLocalizedField } from "@/lib/data";
+import { getPageBySlug, normalizeLocale, resolveLocalizedField } from "@/lib/data";
 import { toMetadataDescription } from "@/lib/utils/metadata";
 
 export const revalidate = 3600;
 
-const locale = "no";
-const fallbackLocale = "en";
+const fallbackLocale = "no";
 
 type InfoPageProps = {
   params: {
     pageSlug: string;
   };
+  searchParams?: { lang?: string | string[] };
 };
 
 export async function generateMetadata({
   params,
+  searchParams,
 }: InfoPageProps): Promise<Metadata> {
   const page = await getPageBySlug(params.pageSlug);
 
@@ -28,6 +30,9 @@ export async function generateMetadata({
     };
   }
 
+  const cookieLocale = cookies().get("lang")?.value;
+  const searchLocale = typeof searchParams?.lang === "string" ? searchParams.lang : null;
+  const locale = normalizeLocale(searchLocale ?? cookieLocale, fallbackLocale);
   const title =
     resolveLocalizedField(page.title, locale, fallbackLocale) ?? "Infoside";
   const descriptionSource = resolveLocalizedField(
@@ -45,7 +50,10 @@ export async function generateMetadata({
   };
 }
 
-export default async function InfoPage({ params }: InfoPageProps) {
+export default async function InfoPage({ params, searchParams }: InfoPageProps) {
+  const cookieLocale = cookies().get("lang")?.value;
+  const searchLocale = typeof searchParams?.lang === "string" ? searchParams.lang : null;
+  const locale = normalizeLocale(searchLocale ?? cookieLocale, fallbackLocale);
   const page = await getPageBySlug(params.pageSlug);
 
   if (!page) {

--- a/app/(public)/kalender/page.tsx
+++ b/app/(public)/kalender/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import Link from "next/link";
 
 import { Card } from "@/components/ui/card";
 import { BodyText, Heading } from "@/components/ui/typography";
-import { getUpcomingEvents, resolveLocalizedField } from "@/lib/data";
+import { getUpcomingEvents, normalizeLocale, resolveLocalizedField } from "@/lib/data";
 
 export const revalidate = 600;
 
-const locale = "no";
-const fallbackLocale = "en";
+const fallbackLocale = "no";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -43,7 +43,14 @@ function formatEventDate(start: string, end: string | null) {
   return `${dateLabel} kl. ${timeLabel} – ${endDateLabel} kl. ${endTimeLabel}`;
 }
 
-export default async function CalendarPage() {
+type CalendarPageProps = {
+  searchParams?: { lang?: string | string[] };
+};
+
+export default async function CalendarPage({ searchParams }: CalendarPageProps) {
+  const cookieLocale = cookies().get("lang")?.value;
+  const searchLocale = typeof searchParams?.lang === "string" ? searchParams.lang : null;
+  const locale = normalizeLocale(searchLocale ?? cookieLocale, fallbackLocale);
   const events = await getUpcomingEvents(24);
 
   return (

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { Suspense } from "react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -28,7 +29,13 @@ export default function PublicLayout({ children }: PropsWithChildren) {
             </Link>
           </nav>
           <div className="flex items-center gap-3">
-            <LanguageToggle />
+            <Suspense
+              fallback={
+                <div className="h-7 w-[72px] rounded-full bg-slate-100" aria-hidden />
+              }
+            >
+              <LanguageToggle />
+            </Suspense>
             <Button variant="secondary" className="hidden md:inline-flex">
               Gi
             </Button>

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from "react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { LanguageToggle } from "@/components/ui/language-toggle";
 
 export default function PublicLayout({ children }: PropsWithChildren) {
   return (
@@ -26,9 +27,12 @@ export default function PublicLayout({ children }: PropsWithChildren) {
               Kontakt
             </Link>
           </nav>
-          <Button variant="secondary" className="hidden md:inline-flex">
-            Gi
-          </Button>
+          <div className="flex items-center gap-3">
+            <LanguageToggle />
+            <Button variant="secondary" className="hidden md:inline-flex">
+              Gi
+            </Button>
+          </div>
         </div>
       </header>
       <main>{children}</main>

--- a/app/(public)/nyheter/page.tsx
+++ b/app/(public)/nyheter/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import Link from "next/link";
 
 import { Card } from "@/components/ui/card";
 import { BodyText, Heading } from "@/components/ui/typography";
-import { getPublishedPosts, resolveLocalizedField } from "@/lib/data";
+import { getPublishedPosts, normalizeLocale, resolveLocalizedField } from "@/lib/data";
 
 export const revalidate = 600;
 
-const locale = "no";
-const fallbackLocale = "en";
+const fallbackLocale = "no";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -17,7 +17,14 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function NewsPage() {
+type NewsPageProps = {
+  searchParams?: { lang?: string | string[] };
+};
+
+export default async function NewsPage({ searchParams }: NewsPageProps) {
+  const cookieLocale = cookies().get("lang")?.value;
+  const searchLocale = typeof searchParams?.lang === "string" ? searchParams.lang : null;
+  const locale = normalizeLocale(searchLocale ?? cookieLocale, fallbackLocale);
   const posts = await getPublishedPosts();
 
   return (

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -65,6 +65,16 @@ export default async function EventDetailPage({
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              defaultValue={event.title?.en ?? ""}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -75,12 +85,20 @@ export default async function EventDetailPage({
           </label>
         </div>
 
-        <MarkdownEditor
-          label="Beskrivelse (Markdown)"
-          name="description"
-          rows={8}
-          defaultValue={event.description_md?.no ?? ""}
-        />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor
+            label="Beskrivelse (NO)"
+            name="description"
+            rows={8}
+            defaultValue={event.description_md?.no ?? ""}
+          />
+          <MarkdownEditor
+            label="Beskrivelse (EN)"
+            name="description_en"
+            rows={8}
+            defaultValue={event.description_md?.en ?? ""}
+          />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/events/actions.ts
+++ b/app/admin/events/actions.ts
@@ -30,8 +30,10 @@ export async function createEvent(formData: FormData) {
   const { data: userData } = await supabase.auth.getUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const description = formData.get("description")?.toString().trim() ?? "";
+  const descriptionEn = formData.get("description_en")?.toString().trim() ?? "";
   const startTime = normalizeDate(formData.get("start_time")?.toString() ?? null);
   const endTime = normalizeDate(formData.get("end_time")?.toString() ?? null);
   const location = formData.get("location")?.toString().trim() ?? "";
@@ -42,8 +44,8 @@ export async function createEvent(formData: FormData) {
     .from("events")
     .insert({
       slug,
-      title: { no: title },
-      description_md: { no: description },
+      title: { no: title, en: titleEn || null },
+      description_md: { no: description, en: descriptionEn || null },
       start_time: startTime,
       end_time: endTime,
       location: location || null,
@@ -67,8 +69,10 @@ export async function updateEvent(eventId: string, formData: FormData) {
   const { data: userData } = await supabase.auth.getUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const description = formData.get("description")?.toString().trim() ?? "";
+  const descriptionEn = formData.get("description_en")?.toString().trim() ?? "";
   const startTime = normalizeDate(formData.get("start_time")?.toString() ?? null);
   const endTime = normalizeDate(formData.get("end_time")?.toString() ?? null);
   const location = formData.get("location")?.toString().trim() ?? "";
@@ -79,8 +83,8 @@ export async function updateEvent(eventId: string, formData: FormData) {
     .from("events")
     .update({
       slug,
-      title: { no: title },
-      description_md: { no: description },
+      title: { no: title, en: titleEn || null },
+      description_md: { no: description, en: descriptionEn || null },
       start_time: startTime,
       end_time: endTime,
       location: location || null,

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -31,6 +31,15 @@ export default function NewEventPage() {
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -40,7 +49,10 @@ export default function NewEventPage() {
           </label>
         </div>
 
-        <MarkdownEditor label="Beskrivelse (Markdown)" name="description" rows={8} />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor label="Beskrivelse (NO)" name="description" rows={8} />
+          <MarkdownEditor label="Beskrivelse (EN)" name="description_en" rows={8} />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/pages/[id]/page.tsx
+++ b/app/admin/pages/[id]/page.tsx
@@ -60,6 +60,16 @@ export default async function PageDetailPage({
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              defaultValue={page.title?.en ?? ""}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -70,12 +80,20 @@ export default async function PageDetailPage({
           </label>
         </div>
 
-        <MarkdownEditor
-          label="Innhold (Markdown)"
-          name="content"
-          rows={12}
-          defaultValue={page.content_md?.no ?? ""}
-        />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor
+            label="Innhold (NO)"
+            name="content"
+            rows={12}
+            defaultValue={page.content_md?.no ?? ""}
+          />
+          <MarkdownEditor
+            label="Innhold (EN)"
+            name="content_en"
+            rows={12}
+            defaultValue={page.content_md?.en ?? ""}
+          />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/pages/actions.ts
+++ b/app/admin/pages/actions.ts
@@ -30,8 +30,10 @@ export async function createPage(formData: FormData) {
   const { data: userData } = await supabase.auth.getUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
+  const contentEn = formData.get("content_en")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
   const publishedAt = normalizeDate(formData.get("published_at")?.toString() ?? null);
 
@@ -39,8 +41,8 @@ export async function createPage(formData: FormData) {
     .from("pages")
     .insert({
       slug,
-      title: { no: title },
-      content_md: { no: content },
+      title: { no: title, en: titleEn || null },
+      content_md: { no: content, en: contentEn || null },
       status,
       published_at: publishedAt,
       updated_by: userData?.user?.id ?? null,
@@ -61,8 +63,10 @@ export async function updatePage(pageId: string, formData: FormData) {
   const { data: userData } = await supabase.auth.getUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
+  const contentEn = formData.get("content_en")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
   const publishedAt = normalizeDate(formData.get("published_at")?.toString() ?? null);
 
@@ -70,8 +74,8 @@ export async function updatePage(pageId: string, formData: FormData) {
     .from("pages")
     .update({
       slug,
-      title: { no: title },
-      content_md: { no: content },
+      title: { no: title, en: titleEn || null },
+      content_md: { no: content, en: contentEn || null },
       status,
       published_at: publishedAt,
       updated_by: userData?.user?.id ?? null,

--- a/app/admin/pages/new/page.tsx
+++ b/app/admin/pages/new/page.tsx
@@ -29,6 +29,15 @@ export default function NewPage() {
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -38,7 +47,10 @@ export default function NewPage() {
           </label>
         </div>
 
-        <MarkdownEditor label="Innhold (Markdown)" name="content" rows={12} />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor label="Innhold (NO)" name="content" rows={12} />
+          <MarkdownEditor label="Innhold (EN)" name="content_en" rows={12} />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -60,6 +60,16 @@ export default async function PostDetailPage({
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              defaultValue={post.title?.en ?? ""}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -70,22 +80,41 @@ export default async function PostDetailPage({
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Sammendrag (NO)
-          <textarea
-            name="excerpt"
-            rows={3}
-            defaultValue={post.excerpt?.no ?? ""}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
+            Sammendrag (NO)
+            <textarea
+              name="excerpt"
+              rows={3}
+              defaultValue={post.excerpt?.no ?? ""}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-slate-200">
+            Sammendrag (EN)
+            <textarea
+              name="excerpt_en"
+              rows={3}
+              defaultValue={post.excerpt?.en ?? ""}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
 
-        <MarkdownEditor
-          label="Innhold (Markdown)"
-          name="content"
-          rows={12}
-          defaultValue={post.content_md?.no ?? ""}
-        />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor
+            label="Innhold (NO)"
+            name="content"
+            rows={12}
+            defaultValue={post.content_md?.no ?? ""}
+          />
+          <MarkdownEditor
+            label="Innhold (EN)"
+            name="content_en"
+            rows={12}
+            defaultValue={post.content_md?.en ?? ""}
+          />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="space-y-2 text-sm text-slate-200">

--- a/app/admin/posts/actions.ts
+++ b/app/admin/posts/actions.ts
@@ -66,9 +66,12 @@ export async function createPost(formData: FormData) {
   const { adminClient, userId } = await requireEditorUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const excerpt = formData.get("excerpt")?.toString().trim() ?? "";
+  const excerptEn = formData.get("excerpt_en")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
+  const contentEn = formData.get("content_en")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
   const publishedAt = normalizePublishedAt(
     status,
@@ -80,9 +83,9 @@ export async function createPost(formData: FormData) {
     .from("posts")
     .insert({
       slug,
-      title: { no: title },
-      excerpt: { no: excerpt },
-      content_md: { no: content },
+      title: { no: title, en: titleEn || null },
+      excerpt: { no: excerpt, en: excerptEn || null },
+      content_md: { no: content, en: contentEn || null },
       status,
       published_at: publishedAt,
       cover_image_path: coverImagePath || null,
@@ -104,9 +107,12 @@ export async function updatePost(postId: string, formData: FormData) {
   const { adminClient, userId } = await requireEditorUser();
 
   const title = formData.get("title")?.toString().trim() ?? "";
+  const titleEn = formData.get("title_en")?.toString().trim() ?? "";
   const slug = formData.get("slug")?.toString().trim() ?? "";
   const excerpt = formData.get("excerpt")?.toString().trim() ?? "";
+  const excerptEn = formData.get("excerpt_en")?.toString().trim() ?? "";
   const content = formData.get("content")?.toString().trim() ?? "";
+  const contentEn = formData.get("content_en")?.toString().trim() ?? "";
   const status = normalizeStatus(formData.get("status")?.toString() ?? null);
   const publishedAt = normalizePublishedAt(
     status,
@@ -118,9 +124,9 @@ export async function updatePost(postId: string, formData: FormData) {
     .from("posts")
     .update({
       slug,
-      title: { no: title },
-      excerpt: { no: excerpt },
-      content_md: { no: content },
+      title: { no: title, en: titleEn || null },
+      excerpt: { no: excerpt, en: excerptEn || null },
+      content_md: { no: content, en: contentEn || null },
       status,
       published_at: publishedAt,
       cover_image_path: coverImagePath || null,

--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -31,6 +31,15 @@ export default function NewPostPage() {
             />
           </label>
           <label className="space-y-2 text-sm text-slate-200">
+            Tittel (EN)
+            <input
+              name="title_en"
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
             Slug
             <input
               name="slug"
@@ -40,16 +49,29 @@ export default function NewPostPage() {
           </label>
         </div>
 
-        <label className="space-y-2 text-sm text-slate-200">
-          Sammendrag (NO)
-          <textarea
-            name="excerpt"
-            rows={3}
-            className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-          />
-        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-200">
+            Sammendrag (NO)
+            <textarea
+              name="excerpt"
+              rows={3}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-slate-200">
+            Sammendrag (EN)
+            <textarea
+              name="excerpt_en"
+              rows={3}
+              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+            />
+          </label>
+        </div>
 
-        <MarkdownEditor label="Innhold (Markdown)" name="content" rows={12} />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <MarkdownEditor label="Innhold (NO)" name="content" rows={12} />
+          <MarkdownEditor label="Innhold (EN)" name="content_en" rows={12} />
+        </div>
 
         <div className="grid gap-4 md:grid-cols-3">
           <label className="space-y-2 text-sm text-slate-200">

--- a/components/ui/language-toggle.tsx
+++ b/components/ui/language-toggle.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { normalizeLocale } from "@/lib/data/localization";
+import { cn } from "@/lib/utils";
+
+const locales = [
+  { value: "no", label: "NO" },
+  { value: "en", label: "EN" },
+] as const;
+
+function readCookieLocale() {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const match = document.cookie.match(/(?:^|; )lang=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function setLanguageCookie(locale: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.cookie = `lang=${encodeURIComponent(locale)}; path=/; max-age=31536000`;
+}
+
+export function LanguageToggle() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [cookieLocale, setCookieLocale] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCookieLocale(readCookieLocale());
+  }, []);
+
+  const currentLocale = useMemo(() => {
+    const searchLocale = searchParams.get("lang");
+    return normalizeLocale(searchLocale ?? cookieLocale ?? "no", "no");
+  }, [searchParams, cookieLocale]);
+
+  const createHref = (locale: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("lang", locale);
+    return `${pathname}?${params.toString()}`;
+  };
+
+  return (
+    <div className="flex items-center gap-1 rounded-full bg-slate-100 p-1 text-xs font-semibold text-slate-600">
+      {locales.map((locale) => {
+        const isActive = currentLocale === locale.value;
+        return (
+          <Link
+            key={locale.value}
+            href={createHref(locale.value)}
+            onClick={() => setLanguageCookie(locale.value)}
+            className={cn(
+              "rounded-full px-3 py-1 transition",
+              isActive
+                ? "bg-white text-slate-900 shadow-sm"
+                : "text-slate-600 hover:text-slate-900"
+            )}
+          >
+            {locale.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ui/language-toggle.tsx
+++ b/components/ui/language-toggle.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
+import type { UrlObject } from "url";
 
 import { normalizeLocale } from "@/lib/data/localization";
 import { cn } from "@/lib/utils";
@@ -41,10 +42,10 @@ export function LanguageToggle() {
     return normalizeLocale(searchLocale ?? cookieLocale ?? "no", "no");
   }, [searchParams, cookieLocale]);
 
-  const createHref = (locale: string) => {
+  const createHref = (locale: string): UrlObject => {
     const params = new URLSearchParams(searchParams.toString());
     params.set("lang", locale);
-    return `${pathname}?${params.toString()}`;
+    return { pathname, query: Object.fromEntries(params.entries()) };
   };
 
   return (

--- a/lib/data/localization.ts
+++ b/lib/data/localization.ts
@@ -2,6 +2,16 @@ export type Locale = "no" | "en" | (string & {});
 
 export type LocalizedField<T> = Record<string, T | null | undefined>;
 
+export function normalizeLocale(
+  value: string | null | undefined,
+  fallback: Locale = "no",
+) {
+  if (value === "no" || value === "en") {
+    return value;
+  }
+  return fallback;
+}
+
 export function resolveLocalizedField<T>(
   field: LocalizedField<T> | null | undefined,
   locale: Locale,


### PR DESCRIPTION
### Motivation
- Provide a frontend language switcher and store user preference in a cookie/query param so public pages can render localized content. 
- Ensure public pages fall back to Norwegian when translations are missing using the existing `resolveLocalizedField` helper. 
- Allow admins to enter English content alongside Norwegian so DB fields store `{ no, en }` JSONB for posts, events and pages.

### Description
- Added `LanguageToggle` component and wired it into the public `layout` to write `lang` as a cookie and propagate `?lang=` in links (`components/ui/language-toggle.tsx`, `app/(public)/layout.tsx`).
- Introduced `normalizeLocale` and updated localization lookup to derive `locale` from `searchParams` or `cookies()` and use `resolveLocalizedField(..., locale, 'no')` across public pages (`lib/data/localization.ts`, `app/(public)/*.tsx`).
- Extended admin forms and server actions to accept EN inputs and persist `title`, `excerpt`, `content_md`, `description_md` and page `content_md` as `{ no, en }` objects (`app/admin/*/new/page.tsx`, `app/admin/*/[id]/page.tsx`, `app/admin/*/actions.ts`).
- Kept fallback behavior so public rendering uses Norwegian when English is missing by passing `fallbackLocale = "no"` into `resolveLocalizedField`.

### Testing
- Started the dev server with `npm run dev` to validate compilation and server components and the server reported ready after fixes (success). 
- Attempted an automated Playwright screenshot to verify the language toggle UI, but the Chromium process crashed in this environment so the screenshot step failed. 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69729a32131c8324884b8c29ee1beb33)