### PR TITLE
Fix profiles RLS recursion with security-definer role helpers

### DIFF
--- a/db/migrations/0003_fix_profiles_rls.sql
+++ b/db/migrations/0003_fix_profiles_rls.sql
@@ -1,0 +1,48 @@
+create or replace function current_cms_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select role
+  from profiles
+  where id = auth.uid();
+$$;
+
+create or replace function is_cms_editor()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select coalesce(current_cms_role() in ('admin', 'editor'), false);
+$$;
+
+create or replace function is_cms_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select coalesce(current_cms_role() = 'admin', false);
+$$;
+
+drop policy if exists "profiles_select_own_or_admin" on profiles;
+create policy "profiles_select_own_or_admin"
+  on profiles for select
+  using (auth.uid() = id or is_cms_admin());
+
+drop policy if exists "profiles_update_own" on profiles;
+create policy "profiles_update_own"
+  on profiles for update
+  using (auth.uid() = id)
+  with check (
+    auth.uid() = id
+    and role = current_cms_role()
+  );


### PR DESCRIPTION
### Motivation

- The profiles row-level security (RLS) checks could recurse into `profiles` lookups and exhaust the database stack depth, causing failures like "stack depth limit exceeded".
- Provide a non-recursive, stable way to read the current user's CMS role from within RLS to avoid recursion and stack overflow.

### Description

- Add a new migration `db/migrations/0003_fix_profiles_rls.sql` that creates `current_cms_role()` implemented as a `security definer` function with `set row_security = off` to read the role without triggering RLS recursion.
- Add `is_cms_editor()` and `is_cms_admin()` functions that call `current_cms_role()` and return safe boolean results, also marked `security definer` with `row_security = off`.
- Replace/recreate the `profiles` policies `profiles_select_own_or_admin` and `profiles_update_own` to use the new helpers and to use `role = current_cms_role()` in the `WITH CHECK` clause to avoid recursive RLS evaluation.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972a133bf14832480d060925080db6b)