### PR TITLE
Harden profile role helpers

### DIFF
--- a/db/migrations/0004_harden_profile_role_helpers.sql
+++ b/db/migrations/0004_harden_profile_role_helpers.sql
@@ -1,0 +1,43 @@
+create or replace function current_cms_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select role
+  from profiles
+  where id = auth.uid();
+$$;
+
+create or replace function is_cms_editor()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select coalesce(current_cms_role() in ('admin', 'editor'), false);
+$$;
+
+create or replace function is_cms_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+set row_security = off
+as $$
+  select coalesce(current_cms_role() = 'admin', false);
+$$;
+
+drop policy if exists "profiles_update_own" on profiles;
+create policy "profiles_update_own"
+  on profiles for update
+  using (auth.uid() = id)
+  with check (
+    auth.uid() = id
+    and role = current_cms_role()
+  );


### PR DESCRIPTION
### Motivation
- Centralize profile role lookup to avoid recursive permission checks and make role checks safe to use inside row-level security policies.
- Reduce the chance of stack-depth or recursive evaluation issues when role-check functions are evaluated by RLS.

### Description
- Add `current_cms_role()` in `db/migrations/0001_init.sql` as a `SECURITY DEFINER` SQL function with `set row_security = off` to read the caller's profile role.
- Update `is_cms_editor()` and `is_cms_admin()` to use `current_cms_role()` and return a safe boolean via `coalesce(...)` when no profile exists.
- Change the `profiles_update_own` policy to compare `role` against `current_cms_role()` instead of using an inline subquery.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979396fec788324ae7d1581aeb010ad)