### PR TITLE
Add scheduled Google Calendar sync endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ npm run sync:google-calendar
 
 Skriptet bruker `slug` som unik nøkkel og gjør en `upsert`, så kjør det gjerne som et cron-jobb.
 
+#### Automatisk cron i Vercel
+Prosjektet har en API-route på `/api/google-calendar-sync` og en cron-konfig i `vercel.json` som kjører daglig kl. 03:00 (UTC).
+
+For å få dette til å kjøre i produksjon:
+1. Legg inn `SUPABASE_URL` og `SUPABASE_SERVICE_ROLE_KEY` i Vercel (Production + Preview).
+2. (Valgfritt) Sett `GOOGLE_CALENDAR_ICS_URL` hvis du vil overstyre kalender-URL.
+3. (Valgfritt) Sett `CRON_SECRET` og bruk den for manuelle kall til API-ruten (`/api/google-calendar-sync?secret=...` eller `x-cron-secret` header).
+
+Vercel Cron-requests inkluderer `x-vercel-cron: 1`, så de vil fungere selv om du har satt `CRON_SECRET`.
+
 
 ### Supabase (milepæl 2)
 - Kjør migrasjonen i `db/migrations/0001_init.sql` i Supabase SQL editor.

--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -28,9 +28,18 @@ function formatDateToken(date: Date) {
   )}${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}`;
 }
 
-function buildSlug(summary: string, startTime?: Date, uid?: string) {
+function buildSlug(
+  summary: string,
+  startTime?: Date,
+  uid?: string,
+  recurrenceId?: Date,
+) {
   const base = summary ? toSlug(summary) : "arrangement";
   if (uid) {
+    const tokenSource = recurrenceId ?? startTime;
+    if (tokenSource) {
+      return `${base}-${uid.split("@")[0]}-${formatDateToken(tokenSource)}`;
+    }
     return `${base}-${uid.split("@")[0]}`;
   }
   if (startTime) {
@@ -77,7 +86,7 @@ async function syncGoogleCalendar() {
     const description = event.description?.trim() || "";
     const startTime = toIsoDate(event.start);
     const endTime = toIsoDate(event.end);
-    const slug = buildSlug(title, event.start, event.uid);
+    const slug = buildSlug(title, event.start, event.uid, event.recurrenceid);
     const status = isCancelled(event) ? "cancelled" : "published";
 
     return {

--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -1,0 +1,141 @@
+import ical from "node-ical";
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const CALENDAR_URL =
+  process.env.GOOGLE_CALENDAR_ICS_URL ||
+  "https://calendar.google.com/calendar/ical/kre9t9q7urd9dspgj107eoklvo%40group.calendar.google.com/public/basic.ics";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const CRON_SECRET = process.env.CRON_SECRET;
+
+function toSlug(value: string) {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+}
+
+function formatDateToken(date: Date) {
+  const pad = (value: number) => `${value}`.padStart(2, "0");
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(
+    date.getUTCDate(),
+  )}${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}`;
+}
+
+function buildSlug(summary: string, startTime?: Date, uid?: string) {
+  const base = summary ? toSlug(summary) : "arrangement";
+  if (uid) {
+    return `${base}-${uid.split("@")[0]}`;
+  }
+  if (startTime) {
+    return `${base}-${formatDateToken(startTime)}`;
+  }
+  return `${base}-${Date.now()}`;
+}
+
+function toIsoDate(value?: Date | string | null) {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString();
+}
+
+function isCancelled(event: { status?: string | null } | null) {
+  return event?.status?.toLowerCase?.() === "cancelled";
+}
+
+async function syncGoogleCalendar() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.",
+    );
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      persistSession: false,
+    },
+  });
+
+  const now = new Date();
+  console.log(`Fetching calendar from ${CALENDAR_URL}`);
+
+  const calendarData = await ical.async.fromURL(CALENDAR_URL);
+  const events = Object.values(calendarData).filter(
+    (entry) => entry?.type === "VEVENT",
+  );
+
+  const records = events.map((event) => {
+    const title = event.summary?.trim() || "Arrangement";
+    const description = event.description?.trim() || "";
+    const startTime = toIsoDate(event.start);
+    const endTime = toIsoDate(event.end);
+    const slug = buildSlug(title, event.start, event.uid);
+    const status = isCancelled(event) ? "cancelled" : "published";
+
+    return {
+      slug,
+      title: { no: title, en: title },
+      description_md: {
+        no: description,
+        en: description,
+      },
+      start_time: startTime,
+      end_time: endTime,
+      location: event.location?.trim() || null,
+      status,
+      published_at: status === "published" ? now.toISOString() : null,
+    };
+  });
+
+  if (!records.length) {
+    return { synced: 0, cancelled: 0 };
+  }
+
+  const { error } = await supabase
+    .from("events")
+    .upsert(records, { onConflict: "slug" });
+
+  if (error) {
+    throw error;
+  }
+
+  const cancelledCount = records.filter(
+    (record) => record.status === "cancelled",
+  ).length;
+
+  return { synced: records.length, cancelled: cancelledCount };
+}
+
+export async function GET(request: Request) {
+  if (CRON_SECRET) {
+    const { searchParams } = new URL(request.url);
+    const token =
+      request.headers.get("x-cron-secret") || searchParams.get("secret");
+
+    if (token !== CRON_SECRET) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const { synced, cancelled } = await syncGoogleCalendar();
+
+    return NextResponse.json({
+      ok: true,
+      synced,
+      cancelled,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Calendar sync failed:", error);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -115,14 +115,13 @@ async function syncGoogleCalendar() {
 }
 
 export async function GET(request: Request) {
-  if (CRON_SECRET) {
-    const { searchParams } = new URL(request.url);
-    const token =
-      request.headers.get("x-cron-secret") || searchParams.get("secret");
+  const { searchParams } = new URL(request.url);
+  const token =
+    request.headers.get("x-cron-secret") || searchParams.get("secret");
+  const isVercelCron = request.headers.get("x-vercel-cron") === "1";
 
-    if (token !== CRON_SECRET) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (CRON_SECRET && token !== CRON_SECRET && !isVercelCron) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "crons": [
+    {
+      "path": "/api/google-calendar-sync",
+      "schedule": "0 3 * * *"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
### Motivation
- Run the existing Google Calendar → Supabase import on a schedule and allow ad-hoc/manual invocations via an HTTP endpoint.
- Provide optional secret protection for scheduled calls so the cron job can be restricted to the deployment environment.

### Description
- Add a Next.js App Router API route at `app/api/google-calendar-sync/route.ts` that implements the calendar sync logic (parses `.ics` with `node-ical`, builds records and `upsert`s into the `events` table using a Supabase service role key) and runs under the `nodejs` runtime.
- The endpoint accepts an optional cron secret via the `x-cron-secret` header or `?secret=` query parameter when `CRON_SECRET` is set and returns a JSON result with `synced` and `cancelled` counts or an error message.
- Update `vercel.json` to add a `crons` entry that hits `/api/google-calendar-sync` on the schedule `0 3 * * *` (daily at 03:00).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a67aa75188324a460360f87c826ce)