### PR TITLE
Add editable slug field with auto-generation for admin edit pages

### DIFF
--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deleteEvent, updateEvent } from "@/app/admin/events/actions";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
+import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -74,15 +75,12 @@ export default async function EventDetailPage({
           </label>
         </div>
         <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Slug
-            <input
-              name="slug"
-              required
-              defaultValue={event.slug}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
+          <SlugField
+            initialSlug={event.slug}
+            slugName="slug"
+            titleInputName="title"
+            required
+          />
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">

--- a/app/admin/pages/[id]/page.tsx
+++ b/app/admin/pages/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deletePage, updatePage } from "@/app/admin/pages/actions";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
+import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -69,15 +70,12 @@ export default async function PageDetailPage({
           </label>
         </div>
         <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Slug
-            <input
-              name="slug"
-              required
-              defaultValue={page.slug}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
+          <SlugField
+            initialSlug={page.slug}
+            slugName="slug"
+            titleInputName="title"
+            required
+          />
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { deletePost, updatePost } from "@/app/admin/posts/actions";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
+import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -69,15 +70,12 @@ export default async function PostDetailPage({
           </label>
         </div>
         <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Slug
-            <input
-              name="slug"
-              required
-              defaultValue={post.slug}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
+          <SlugField
+            initialSlug={post.slug}
+            slugName="slug"
+            titleInputName="title"
+            required
+          />
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/app/admin/sermons/[id]/page.tsx
+++ b/app/admin/sermons/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deleteSermon, updateSermon } from "@/app/admin/sermons/actions";
+import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 function formatDateTime(value: string | null) {
@@ -60,15 +61,12 @@ export default async function SermonDetailPage({
               className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
             />
           </label>
-          <label className="space-y-2 text-sm text-slate-200">
-            Slug
-            <input
-              name="slug"
-              required
-              defaultValue={sermon.slug}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
+          <SlugField
+            initialSlug={sermon.slug}
+            slugName="slug"
+            titleInputName="title"
+            required
+          />
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/components/admin/slug-field.tsx
+++ b/components/admin/slug-field.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+type SlugFieldProps = {
+  initialSlug?: string | null;
+  slugName: string;
+  titleInputName: string;
+  required?: boolean;
+};
+
+export function SlugField({
+  initialSlug,
+  slugName,
+  titleInputName,
+  required,
+}: SlugFieldProps) {
+  const [isEditable, setIsEditable] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const slugInput = inputRef.current;
+    if (!slugInput) {
+      return;
+    }
+    const form = slugInput.form;
+    if (!form) {
+      return;
+    }
+    const titleInput = form.querySelector<HTMLInputElement>(
+      `input[name="${titleInputName}"]`
+    );
+    if (!titleInput) {
+      return;
+    }
+    const handleTitleChange = () => {
+      if (slugInput.value.trim() !== "") {
+        return;
+      }
+      slugInput.value = slugify(titleInput.value);
+    };
+    handleTitleChange();
+    titleInput.addEventListener("input", handleTitleChange);
+    return () => {
+      titleInput.removeEventListener("input", handleTitleChange);
+    };
+  }, [titleInputName]);
+
+  return (
+    <label className="space-y-2 text-sm text-slate-200">
+      <span className="flex items-center justify-between gap-2">
+        Slug
+        <button
+          type="button"
+          onClick={() => setIsEditable((prev) => !prev)}
+          className="text-xs font-semibold text-slate-400 hover:text-white"
+        >
+          {isEditable ? "Lock slug" : "Edit slug"}
+        </button>
+      </span>
+      <input
+        ref={inputRef}
+        name={slugName}
+        required={required}
+        defaultValue={initialSlug ?? ""}
+        readOnly={!isEditable}
+        className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+      />
+    </label>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make slug management easier by auto-generating a slug from the title only when the slug is empty, show it read-only by default, and allow editors to unlock and edit it when needed.

### Description
- Add a reusable client component `components/admin/slug-field.tsx` that slugifies a title, only populates the slug when the slug input is empty, and exposes an “Edit slug” toggle to unlock the field.
- Wire the new `SlugField` into the edit pages for posts, events, pages and sermons (`app/admin/posts/[id]/page.tsx`, `app/admin/events/[id]/page.tsx`, `app/admin/pages/[id]/page.tsx`, `app/admin/sermons/[id]/page.tsx`) replacing the previous slug inputs.
- Slug generation uses a Unicode-normalizing `slugify` function and the component finds the title input by `name` to keep forms plain-HTML-friendly and avoid changing server actions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989f96132188324904cf000d730a8c0)