### PR TITLE
Persist admin markdown drafts by record

### DIFF
--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -87,12 +87,14 @@ export default async function EventDetailPage({
           <MarkdownEditor
             label="Beskrivelse (NO)"
             name="description"
+            recordId={`event-${event.id}`}
             rows={8}
             defaultValue={event.description_md?.no ?? ""}
           />
           <MarkdownEditor
             label="Beskrivelse (EN)"
             name="description_en"
+            recordId={`event-${event.id}`}
             rows={8}
             defaultValue={event.description_md?.en ?? ""}
           />

--- a/app/admin/events/new/page.tsx
+++ b/app/admin/events/new/page.tsx
@@ -50,8 +50,18 @@ export default function NewEventPage() {
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor label="Beskrivelse (NO)" name="description" rows={8} />
-          <MarkdownEditor label="Beskrivelse (EN)" name="description_en" rows={8} />
+          <MarkdownEditor
+            label="Beskrivelse (NO)"
+            name="description"
+            recordId="event-new"
+            rows={8}
+          />
+          <MarkdownEditor
+            label="Beskrivelse (EN)"
+            name="description_en"
+            recordId="event-new"
+            rows={8}
+          />
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/app/admin/pages/[id]/page.tsx
+++ b/app/admin/pages/[id]/page.tsx
@@ -82,12 +82,14 @@ export default async function PageDetailPage({
           <MarkdownEditor
             label="Innhold (NO)"
             name="content"
+            recordId={`page-${page.id}`}
             rows={12}
             defaultValue={page.content_md?.no ?? ""}
           />
           <MarkdownEditor
             label="Innhold (EN)"
             name="content_en"
+            recordId={`page-${page.id}`}
             rows={12}
             defaultValue={page.content_md?.en ?? ""}
           />

--- a/app/admin/pages/new/page.tsx
+++ b/app/admin/pages/new/page.tsx
@@ -48,8 +48,18 @@ export default function NewPage() {
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor label="Innhold (NO)" name="content" rows={12} />
-          <MarkdownEditor label="Innhold (EN)" name="content_en" rows={12} />
+          <MarkdownEditor
+            label="Innhold (NO)"
+            name="content"
+            recordId="page-new"
+            rows={12}
+          />
+          <MarkdownEditor
+            label="Innhold (EN)"
+            name="content_en"
+            recordId="page-new"
+            rows={12}
+          />
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -103,12 +103,14 @@ export default async function PostDetailPage({
           <MarkdownEditor
             label="Innhold (NO)"
             name="content"
+            recordId={`post-${post.id}`}
             rows={12}
             defaultValue={post.content_md?.no ?? ""}
           />
           <MarkdownEditor
             label="Innhold (EN)"
             name="content_en"
+            recordId={`post-${post.id}`}
             rows={12}
             defaultValue={post.content_md?.en ?? ""}
           />

--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -69,8 +69,18 @@ export default function NewPostPage() {
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor label="Innhold (NO)" name="content" rows={12} />
-          <MarkdownEditor label="Innhold (EN)" name="content_en" rows={12} />
+          <MarkdownEditor
+            label="Innhold (NO)"
+            name="content"
+            recordId="post-new"
+            rows={12}
+          />
+          <MarkdownEditor
+            label="Innhold (EN)"
+            name="content_en"
+            recordId="post-new"
+            rows={12}
+          />
         </div>
 
         <div className="grid gap-4 md:grid-cols-3">


### PR DESCRIPTION
### Motivation
- Preserve unsaved markdown edits in the admin UI so users don't lose work while editing records. 
- Scope drafts to a stable key composed of `name` + record id so drafts don't collide across records or locales. 
- Warn users on `beforeunload` when local edits differ from the loaded server content and clear drafts when a form is saved. 

### Description
- Added a `recordId` prop to `MarkdownEditor` and use a storage key of the form `markdown-draft:${name}:${recordId}` to scope drafts. 
- Load a saved draft on mount only when the draft's stored `serverValue` matches the current `defaultValue`, otherwise remove the stale draft. 
- Persist changes to `localStorage` whenever the editor value diverges from `defaultValue`, add a `beforeunload` handler that warns if local edits differ from the initial server content, and remove the draft on form `submit`. 
- Updated all admin usages of `MarkdownEditor` (posts/pages/events create and edit screens) to pass stable `recordId` values (including `*-new` for new records). 

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989fb812c708324a2f0778dc0fce129)