### PR TITLE
Add media picker modal for selecting post cover images

### DIFF
--- a/app/admin/media/actions.ts
+++ b/app/admin/media/actions.ts
@@ -1,12 +1,15 @@
-"use server";
+'use server';
 
-import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
 
-import { createSupabaseAdminClient, createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  createSupabaseAdminClient,
+  createSupabaseServerClient,
+} from '@/lib/supabase/server';
 
-const editorRoles = new Set(["admin", "editor"]);
-const allowedBuckets = new Set(["images", "podcasts"]);
+const editorRoles = new Set(['admin', 'editor']);
+const allowedBuckets = new Set(['images', 'podcasts']);
 
 async function requireEditorUser() {
   const supabase = createSupabaseServerClient();
@@ -15,14 +18,14 @@ async function requireEditorUser() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    throw new Error("User not authenticated.");
+    throw new Error('User not authenticated.');
   }
 
   const adminClient = createSupabaseAdminClient();
   const { data: profile, error } = await adminClient
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
     .maybeSingle();
 
   if (error) {
@@ -30,7 +33,7 @@ async function requireEditorUser() {
   }
 
   if (!profile || !editorRoles.has(profile.role)) {
-    throw new Error("User does not have permission to manage media.");
+    throw new Error('User does not have permission to manage media.');
   }
 
   return { adminClient };
@@ -40,22 +43,22 @@ function resolveBucket(value: string | null) {
   if (value && allowedBuckets.has(value)) {
     return value;
   }
-  return "images";
+  return 'images';
 }
 
 export async function uploadMedia(formData: FormData) {
   const { adminClient } = await requireEditorUser();
-  const bucket = resolveBucket(formData.get("bucket")?.toString() ?? null);
-  const file = formData.get("file");
+  const bucket = resolveBucket(formData.get('bucket')?.toString() ?? null);
+  const file = formData.get('file');
 
   if (!(file instanceof File) || file.size === 0) {
-    throw new Error("No file selected.");
+    throw new Error('No file selected.');
   }
 
-  const rawPath = formData.get("path")?.toString().trim() ?? "";
-  const path = (rawPath || file.name).replace(/^\/+/, "");
-  const alt = formData.get("alt")?.toString().trim() ?? "";
-  const caption = formData.get("caption")?.toString().trim() ?? "";
+  const rawPath = formData.get('path')?.toString().trim() ?? '';
+  const path = (rawPath || file.name).replace(/^\/+/, '');
+  const alt = formData.get('alt')?.toString().trim() ?? '';
+  const caption = formData.get('caption')?.toString().trim() ?? '';
 
   const { error: uploadError } = await adminClient.storage
     .from(bucket)
@@ -68,20 +71,42 @@ export async function uploadMedia(formData: FormData) {
     throw new Error(uploadError.message);
   }
 
-  const { error: insertError } = await adminClient.from("media").upsert(
+  const { error: insertError } = await adminClient.from('media').upsert(
     {
       bucket,
       path,
       alt: { no: alt },
       caption: caption ? { no: caption } : null,
     },
-    { onConflict: "bucket,path" }
+    { onConflict: 'bucket,path' },
   );
 
   if (insertError) {
     throw new Error(insertError.message);
   }
 
-  revalidatePath("/admin/media");
-  redirect("/admin/media");
+  revalidatePath('/admin/media');
+  redirect('/admin/media');
+}
+
+export async function updateMediaMetadata(mediaId: string, formData: FormData) {
+  const { adminClient } = await requireEditorUser();
+
+  const alt = formData.get('alt')?.toString().trim() ?? '';
+  const caption = formData.get('caption')?.toString().trim() ?? '';
+
+  const { error } = await adminClient
+    .from('media')
+    .update({
+      alt: { no: alt },
+      caption: caption ? { no: caption } : null,
+    })
+    .eq('id', mediaId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath('/admin/media');
+  revalidatePath('/admin/posts');
 }

--- a/components/admin/media-picker.tsx
+++ b/components/admin/media-picker.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import Image from 'next/image';
+import { useMemo, useState } from 'react';
+
+import { updateMediaMetadata } from '@/app/admin/media/actions';
+
+type MediaItem = {
+  id: string;
+  bucket: string;
+  path: string;
+  alt: { no?: string | null; en?: string | null } | null;
+  caption: { no?: string | null; en?: string | null } | null;
+  publicUrl: string;
+};
+
+export function MediaPicker({
+  items,
+  inputName,
+  initialValue,
+  label = 'Velg bilde',
+}: {
+  items: MediaItem[];
+  inputName: string;
+  initialValue?: string | null;
+  label?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedPath, setSelectedPath] = useState(initialValue ?? '');
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.path === selectedPath) ?? null,
+    [items, selectedPath],
+  );
+
+  const filteredItems = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) {
+      return items;
+    }
+
+    return items.filter((item) => {
+      const haystack = `${item.bucket}/${item.path} ${item.alt?.no ?? ''} ${item.caption?.no ?? ''}`;
+      return haystack.toLowerCase().includes(trimmed);
+    });
+  }, [items, query]);
+
+  return (
+    <div className="space-y-3">
+      <input type="hidden" name={inputName} value={selectedPath} readOnly />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-100 hover:border-slate-500"
+        >
+          {label}
+        </button>
+        {selectedPath ? (
+          <button
+            type="button"
+            onClick={() => setSelectedPath('')}
+            className="rounded-full border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500"
+          >
+            Fjern valg
+          </button>
+        ) : null}
+      </div>
+
+      <p className="text-sm text-slate-300">
+        {selectedPath ? `Valgt: ${selectedPath}` : 'Ingen fil valgt'}
+      </p>
+
+      {selectedItem ? (
+        <p className="text-xs text-slate-400">
+          Alt: {selectedItem.alt?.no || '-'} · Bildetekst:{' '}
+          {selectedItem.caption?.no || '-'}
+        </p>
+      ) : null}
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4">
+          <div className="max-h-[85vh] w-full max-w-5xl overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 shadow-xl">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-800 p-4">
+              <h3 className="text-lg font-semibold text-slate-100">
+                Media picker
+              </h3>
+              <div className="flex items-center gap-2">
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Søk i sti eller metadata"
+                  className="rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="rounded-full border border-slate-700 px-4 py-2 text-sm text-slate-200"
+                >
+                  Lukk
+                </button>
+              </div>
+            </div>
+
+            <div className="max-h-[70vh] overflow-y-auto p-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                {filteredItems.map((item) => (
+                  <article
+                    key={item.id}
+                    className="space-y-3 rounded-xl border border-slate-800 bg-slate-950/60 p-4"
+                  >
+                    {item.bucket === 'images' ? (
+                      <Image
+                        src={item.publicUrl}
+                        alt={item.alt?.no ?? item.path}
+                        width={640}
+                        height={320}
+                        className="h-40 w-full rounded-lg object-cover"
+                        unoptimized
+                      />
+                    ) : null}
+
+                    <div>
+                      <p className="font-medium text-slate-100">{item.path}</p>
+                      <p className="text-xs text-slate-400">
+                        Bucket: {item.bucket}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSelectedPath(item.path);
+                          setIsOpen(false);
+                        }}
+                        className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900"
+                      >
+                        Velg
+                      </button>
+                      <a
+                        href={item.publicUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-brand-400 hover:text-brand-300"
+                      >
+                        Åpne fil
+                      </a>
+                    </div>
+
+                    <form
+                      action={updateMediaMetadata.bind(null, item.id)}
+                      className="space-y-2"
+                    >
+                      <label className="block space-y-1 text-xs text-slate-300">
+                        Alt-tekst (NO)
+                        <input
+                          name="alt"
+                          defaultValue={item.alt?.no ?? ''}
+                          className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                        />
+                      </label>
+                      <label className="block space-y-1 text-xs text-slate-300">
+                        Bildetekst (NO)
+                        <input
+                          name="caption"
+                          defaultValue={item.caption?.no ?? ''}
+                          className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                        />
+                      </label>
+                      <button
+                        type="submit"
+                        className="rounded-full border border-slate-600 px-3 py-1.5 text-xs text-slate-100"
+                      >
+                        Lagre metadata
+                      </button>
+                    </form>
+                  </article>
+                ))}
+              </div>
+
+              {!filteredItems.length ? (
+                <p className="py-10 text-center text-sm text-slate-400">
+                  Ingen media funnet.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the free-text `cover_image_path` input with an interactive picker so editors can browse the `media` table and reliably select cover images. 
- Allow inline editing of `alt` and `caption` metadata where media is chosen to make metadata updates quick and contextual. 
- Provide previews (public URLs) for media items and a searchable modal UI to improve admin UX when attaching images to posts. 

### Description
- Add a client-side `MediaPicker` component at `components/admin/media-picker.tsx` that shows a modal UI, supports searching/filtering, previews images (uses `next/image`), writes the selected `path` into a hidden input, and exposes inline forms to edit alt/caption. 
- Update `app/admin/posts/[id]/page.tsx` to fetch recent `media` rows, build public URLs via Supabase storage, and replace the previous `cover_image_path` text input with the `MediaPicker` component. 
- Add a server action `updateMediaMetadata(mediaId, formData)` in `app/admin/media/actions.ts` that persists `alt` and `caption` updates to the `media` table and revalidates admin paths. 

### Testing
- Ran `npm run lint`, which completed successfully (only pre-existing image warnings in public news pages). 
- Ran `npm run build`, which failed to prerender certain admin pages because Supabase environment secrets are not configured in this environment. 
- Executed a headless Playwright script to open the admin post edit page and capture a screenshot of the picker UI, which produced an artifact confirming the component renders in the running dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cc7ad2a0c83249e2bf8d56c93d545)