### PR TITLE
Add language toggle to localized admin editors

### DIFF
--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deleteEvent, updateEvent } from "@/app/admin/events/actions";
+import { LanguageToggleFields } from "@/components/admin/language-toggle-fields";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -55,48 +56,53 @@ export default async function EventDetailPage({
       </div>
 
       <form action={updateEvent.bind(null, event.id)} className="space-y-6">
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (NO)
-            <input
-              name="title"
-              required
-              defaultValue={event.title?.no ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (EN)
-            <input
-              name="title_en"
-              defaultValue={event.title?.en ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-        </div>
+        <LanguageToggleFields
+          noContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (NO)
+                <input
+                  name="title"
+                  required
+                  defaultValue={event.title?.no ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Beskrivelse (NO)"
+                name="description"
+                recordId={`event-${event.id}`}
+                rows={8}
+                defaultValue={event.description_md?.no ?? ""}
+              />
+            </div>
+          }
+          enContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (EN)
+                <input
+                  name="title_en"
+                  defaultValue={event.title?.en ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Beskrivelse (EN)"
+                name="description_en"
+                recordId={`event-${event.id}`}
+                rows={8}
+                defaultValue={event.description_md?.en ?? ""}
+              />
+            </div>
+          }
+        />
         <div className="grid gap-4 md:grid-cols-2">
           <SlugField
             initialSlug={event.slug}
             slugName="slug"
             titleInputName="title"
             required
-          />
-        </div>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor
-            label="Beskrivelse (NO)"
-            name="description"
-            recordId={`event-${event.id}`}
-            rows={8}
-            defaultValue={event.description_md?.no ?? ""}
-          />
-          <MarkdownEditor
-            label="Beskrivelse (EN)"
-            name="description_en"
-            recordId={`event-${event.id}`}
-            rows={8}
-            defaultValue={event.description_md?.en ?? ""}
           />
         </div>
 

--- a/app/admin/pages/[id]/page.tsx
+++ b/app/admin/pages/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deletePage, updatePage } from "@/app/admin/pages/actions";
+import { LanguageToggleFields } from "@/components/admin/language-toggle-fields";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -50,48 +51,53 @@ export default async function PageDetailPage({
       </div>
 
       <form action={updatePage.bind(null, page.id)} className="space-y-6">
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (NO)
-            <input
-              name="title"
-              required
-              defaultValue={page.title?.no ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (EN)
-            <input
-              name="title_en"
-              defaultValue={page.title?.en ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-        </div>
+        <LanguageToggleFields
+          noContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (NO)
+                <input
+                  name="title"
+                  required
+                  defaultValue={page.title?.no ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Innhold (NO)"
+                name="content"
+                recordId={`page-${page.id}`}
+                rows={12}
+                defaultValue={page.content_md?.no ?? ""}
+              />
+            </div>
+          }
+          enContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (EN)
+                <input
+                  name="title_en"
+                  defaultValue={page.title?.en ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Innhold (EN)"
+                name="content_en"
+                recordId={`page-${page.id}`}
+                rows={12}
+                defaultValue={page.content_md?.en ?? ""}
+              />
+            </div>
+          }
+        />
         <div className="grid gap-4 md:grid-cols-2">
           <SlugField
             initialSlug={page.slug}
             slugName="slug"
             titleInputName="title"
             required
-          />
-        </div>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor
-            label="Innhold (NO)"
-            name="content"
-            recordId={`page-${page.id}`}
-            rows={12}
-            defaultValue={page.content_md?.no ?? ""}
-          />
-          <MarkdownEditor
-            label="Innhold (EN)"
-            name="content_en"
-            recordId={`page-${page.id}`}
-            rows={12}
-            defaultValue={page.content_md?.en ?? ""}
           />
         </div>
 

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { deletePost, updatePost } from "@/app/admin/posts/actions";
+import { LanguageToggleFields } from "@/components/admin/language-toggle-fields";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
 import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -50,69 +51,71 @@ export default async function PostDetailPage({
       </div>
 
       <form action={updatePost.bind(null, post.id)} className="space-y-6">
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (NO)
-            <input
-              name="title"
-              required
-              defaultValue={post.title?.no ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-          <label className="space-y-2 text-sm text-slate-200">
-            Tittel (EN)
-            <input
-              name="title_en"
-              defaultValue={post.title?.en ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-        </div>
+        <LanguageToggleFields
+          noContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (NO)
+                <input
+                  name="title"
+                  required
+                  defaultValue={post.title?.no ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <label className="space-y-2 text-sm text-slate-200">
+                Sammendrag (NO)
+                <textarea
+                  name="excerpt"
+                  rows={3}
+                  defaultValue={post.excerpt?.no ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Innhold (NO)"
+                name="content"
+                recordId={`post-${post.id}`}
+                rows={12}
+                defaultValue={post.content_md?.no ?? ""}
+              />
+            </div>
+          }
+          enContent={
+            <div className="space-y-4">
+              <label className="space-y-2 text-sm text-slate-200">
+                Tittel (EN)
+                <input
+                  name="title_en"
+                  defaultValue={post.title?.en ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <label className="space-y-2 text-sm text-slate-200">
+                Sammendrag (EN)
+                <textarea
+                  name="excerpt_en"
+                  rows={3}
+                  defaultValue={post.excerpt?.en ?? ""}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
+                />
+              </label>
+              <MarkdownEditor
+                label="Innhold (EN)"
+                name="content_en"
+                recordId={`post-${post.id}`}
+                rows={12}
+                defaultValue={post.content_md?.en ?? ""}
+              />
+            </div>
+          }
+        />
         <div className="grid gap-4 md:grid-cols-2">
           <SlugField
             initialSlug={post.slug}
             slugName="slug"
             titleInputName="title"
             required
-          />
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="space-y-2 text-sm text-slate-200">
-            Sammendrag (NO)
-            <textarea
-              name="excerpt"
-              rows={3}
-              defaultValue={post.excerpt?.no ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-          <label className="space-y-2 text-sm text-slate-200">
-            Sammendrag (EN)
-            <textarea
-              name="excerpt_en"
-              rows={3}
-              defaultValue={post.excerpt?.en ?? ""}
-              className="w-full rounded-xl border border-slate-800 bg-slate-950 px-4 py-2"
-            />
-          </label>
-        </div>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <MarkdownEditor
-            label="Innhold (NO)"
-            name="content"
-            recordId={`post-${post.id}`}
-            rows={12}
-            defaultValue={post.content_md?.no ?? ""}
-          />
-          <MarkdownEditor
-            label="Innhold (EN)"
-            name="content_en"
-            recordId={`post-${post.id}`}
-            rows={12}
-            defaultValue={post.content_md?.en ?? ""}
           />
         </div>
 

--- a/components/admin/language-toggle-fields.tsx
+++ b/components/admin/language-toggle-fields.tsx
@@ -49,8 +49,20 @@ export function LanguageToggleFields({
         </div>
       </div>
 
-      <div className={activeLanguage === "no" ? "block" : "hidden"}>{noContent}</div>
-      <div className={activeLanguage === "en" ? "block" : "hidden"}>{enContent}</div>
+      <fieldset
+        disabled={activeLanguage !== "no"}
+        aria-hidden={activeLanguage !== "no"}
+        className={activeLanguage === "no" ? "block" : "hidden"}
+      >
+        {noContent}
+      </fieldset>
+      <fieldset
+        disabled={activeLanguage !== "en"}
+        aria-hidden={activeLanguage !== "en"}
+        className={activeLanguage === "en" ? "block" : "hidden"}
+      >
+        {enContent}
+      </fieldset>
     </section>
   );
 }

--- a/components/admin/language-toggle-fields.tsx
+++ b/components/admin/language-toggle-fields.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+type LanguageToggleFieldsProps = {
+  noContent: ReactNode;
+  enContent: ReactNode;
+  noLabel?: string;
+  enLabel?: string;
+};
+
+export function LanguageToggleFields({
+  noContent,
+  enContent,
+  noLabel = "NO",
+  enLabel = "EN",
+}: LanguageToggleFieldsProps) {
+  const [activeLanguage, setActiveLanguage] = useState<"no" | "en">("no");
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-slate-800/80 bg-slate-900/40 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Language</p>
+        <div className="inline-flex rounded-full border border-slate-700 bg-slate-950 p-1 text-sm">
+          <button
+            type="button"
+            onClick={() => setActiveLanguage("no")}
+            aria-pressed={activeLanguage === "no"}
+            className={`rounded-full px-3 py-1 transition ${
+              activeLanguage === "no"
+                ? "bg-white text-slate-900"
+                : "text-slate-300 hover:text-white"
+            }`}
+          >
+            {noLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveLanguage("en")}
+            aria-pressed={activeLanguage === "en"}
+            className={`rounded-full px-3 py-1 transition ${
+              activeLanguage === "en"
+                ? "bg-white text-slate-900"
+                : "text-slate-300 hover:text-white"
+            }`}
+          >
+            {enLabel}
+          </button>
+        </div>
+      </div>
+
+      <div className={activeLanguage === "no" ? "block" : "hidden"}>{noContent}</div>
+      <div className={activeLanguage === "en" ? "block" : "hidden"}>{enContent}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in admin editors by showing only one language's localized fields at a time while keeping the current data model and form names unchanged.
- Improve editor focus for posts, events and pages where NO/EN localized fields were previously rendered side-by-side.

### Description
- Add a reusable client component `components/admin/language-toggle-fields.tsx` that provides a NO/EN toggle and conditional panels.
- Update `app/admin/posts/[id]/page.tsx` to wrap title, excerpt and markdown content in `LanguageToggleFields` so only the active language fields are visible.
- Apply the same pattern to `app/admin/events/[id]/page.tsx` (title + description) and `app/admin/pages/[id]/page.tsx` (title + content).
- Keep form field names and the server-side data model unchanged so existing update/delete actions continue to work without migration.

### Testing
- Ran `npm run lint`, which completed successfully with unrelated existing warnings about `<img>` usage in public news pages.
- Attempted to run the dev server with `npm run dev` for visual verification, but middleware failed due to missing Supabase URL/key environment variables in the test environment.
- Performed a Playwright-based visual check that produced a screenshot artifact of `/admin/posts`, but full page rendering was impacted by the missing Supabase config.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cc7d217548324b6cc103f6fa9f2b7)