### PR TITLE
Resolve and normalize public image URLs for news and homepage

### DIFF
--- a/app/(public)/nyheter/[slug]/page.tsx
+++ b/app/(public)/nyheter/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
+import Image from "next/image";
 import { notFound } from "next/navigation";
 
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { BodyText, Heading } from "@/components/ui/typography";
 import { getPostBySlug, normalizeLocale, resolveLocalizedField } from "@/lib/data";
 import { toMetadataDescription } from "@/lib/utils/metadata";
+import { resolvePublicImageUrl } from "@/lib/utils/media";
 
 export const revalidate = 1800;
 
@@ -73,6 +75,7 @@ export default async function NewsDetailPage({
     resolveLocalizedField(post.content_md, locale, fallbackLocale) ??
     "Innholdet er ikke tilgjengelig ennå.";
   const publishedAt = post.published_at ? formatPublishedDate(post.published_at) : null;
+  const coverImageUrl = resolvePublicImageUrl(post.cover_image_path);
 
   return (
     <article className="container-layout space-y-8 py-16">
@@ -83,10 +86,12 @@ export default async function NewsDetailPage({
         </BodyText>
       </header>
 
-      {post.cover_image_path ? (
-        <img
-          src={post.cover_image_path}
+      {coverImageUrl ? (
+        <Image
+          src={coverImageUrl}
           alt={title}
+          width={1440}
+          height={640}
           className="h-80 w-full rounded-2xl object-cover"
         />
       ) : null}

--- a/app/(public)/nyheter/page.tsx
+++ b/app/(public)/nyheter/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
+import Image from "next/image";
 import Link from "next/link";
 
 import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { BodyText, Heading } from "@/components/ui/typography";
 import { getPublishedPosts, normalizeLocale, resolveLocalizedField } from "@/lib/data";
+import { resolvePublicImageUrl } from "@/lib/utils/media";
 
 export const revalidate = 600;
 
@@ -47,14 +49,17 @@ export default async function NewsPage({ searchParams }: NewsPageProps) {
               resolveLocalizedField(post.excerpt, locale, fallbackLocale) ??
               "Les mer om denne oppdateringen.";
 
+            const coverImageUrl = resolvePublicImageUrl(post.cover_image_path);
+
             return (
               <Card key={post.id} className="flex h-full flex-col gap-4">
-                {post.cover_image_path ? (
-                  <img
-                    src={post.cover_image_path}
+                {coverImageUrl ? (
+                  <Image
+                    src={coverImageUrl}
                     alt={title}
+                    width={800}
+                    height={384}
                     className="h-48 w-full rounded-xl object-cover"
-                    loading="lazy"
                   />
                 ) : (
                   <div className="flex h-48 items-center justify-center rounded-xl bg-[#efe5d8] text-sm text-stone-600">

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -13,6 +13,7 @@ import {
   normalizeLocale,
   resolveLocalizedField,
 } from "@/lib/data";
+import { resolvePublicImageUrl } from "@/lib/utils/media";
 
 export const revalidate = 600;
 
@@ -57,7 +58,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
     "Vi oppdaterer programmet snart. Følg med for detaljer om neste arrangement.";
   const nextEventDate = nextEvent?.start_time ? formatEventDate(nextEvent.start_time) : null;
   const nextEventLocation = nextEvent?.location ?? "Sted annonseres snart";
-  const nextEventImage = nextEvent?.cover_image_path ?? defaultEventImage;
+  const nextEventImage = resolvePublicImageUrl(nextEvent?.cover_image_path) ?? defaultEventImage;
 
   return (
     <div>
@@ -171,7 +172,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
                   <Card key={post.id} className="space-y-3">
                     <div className="relative h-40 overflow-hidden rounded-xl">
                       <Image
-                        src={post.cover_image_path ?? defaultPostImage}
+                        src={resolvePublicImageUrl(post.cover_image_path) ?? defaultPostImage}
                         alt={title}
                         fill
                         sizes="(max-width: 768px) 100vw, 33vw"

--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { deletePost, updatePost } from "@/app/admin/posts/actions";
 import { LanguageToggleFields } from "@/components/admin/language-toggle-fields";
 import { MarkdownEditor } from "@/components/admin/markdown-editor";
+import { MediaPicker } from "@/components/admin/media-picker";
 import { SlugField } from "@/components/admin/slug-field";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 

--- a/lib/utils/media.ts
+++ b/lib/utils/media.ts
@@ -1,0 +1,29 @@
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "") ?? "";
+
+export function resolvePublicImageUrl(
+  source: string | null | undefined,
+  bucket = "images"
+): string | null {
+  if (!source) {
+    return null;
+  }
+
+  const value = source.trim();
+  if (!value) {
+    return null;
+  }
+
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return value;
+  }
+
+  if (value.startsWith("/")) {
+    return value;
+  }
+
+  if (!supabaseUrl) {
+    return null;
+  }
+
+  return `${supabaseUrl}/storage/v1/object/public/${bucket}/${value.replace(/^\/+/, "")}`;
+}


### PR DESCRIPTION
### Motivation
- CMS-stored image values can be absolute URLs, site-relative paths, or storage object keys, and rendering them raw caused brittle image display and inconsistent optimization behavior.
- The previous changes left review concerns about image source normalization and `next/image` usage, so a small utility and targeted page updates are needed to make image handling robust.

### Description
- Added `lib/utils/media.ts` with `resolvePublicImageUrl(source, bucket)` to return a usable public URL for absolute URLs, site-relative paths, or Supabase storage keys, and to return `null` for empty/invalid values.
- Updated `app/(public)/nyheter/page.tsx` to resolve `post.cover_image_path` via the new resolver and render `next/image` only when a valid URL exists.
- Updated `app/(public)/nyheter/[slug]/page.tsx` to resolve the post cover image and replace raw `<img>` usage with `next/image` including explicit `width`/`height`.
- Updated `app/(public)/page.tsx` to resolve event/post images via the resolver and make homepage images consistently use `next/image`; also added an import of the new utility.
- Added `MediaPicker` import to `app/admin/posts/[id]/page.tsx` to align admin post editing with existing media picker component.

### Testing
- `npm run lint` completed with no ESLint warnings or errors.
- `npm run build` compiled and completed lint/type checks, but prerendering failed for admin routes due to missing Supabase environment variables (`NEXT_PUBLIC_SUPABASE_URL` / anon key) in this environment, which is an environment configuration issue unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989b989f3f88324b164accd118b5d95)