### PR TITLE
Fix Google Calendar Recurring Events and Sync Logic

### DIFF
--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -49,12 +49,14 @@ export async function getUpcomingEvents(limit: number) {
   const supabase = createSupabaseServerClient();
   const now = publishedFilter.now();
   const publishedAtFilter = `published_at.is.null,published_at.lte.${now}`;
+  const upcomingFilter = `start_time.gte.${now},end_time.gte.${now}`;
+
   const primaryQuery = supabase
     .from("events")
     .select(eventSelectWithCoverImage)
     .eq("status", publishedFilter.status)
     .or(publishedAtFilter)
-    .gte("start_time", now)
+    .or(upcomingFilter)
     .order("start_time", { ascending: true })
     .limit(limit);
 
@@ -73,7 +75,7 @@ export async function getUpcomingEvents(limit: number) {
     .select(eventSelectLegacy)
     .eq("status", publishedFilter.status)
     .or(publishedAtFilter)
-    .gte("start_time", now)
+    .or(upcomingFilter)
     .order("start_time", { ascending: true })
     .limit(limit);
 

--- a/scripts/sync-google-calendar.mjs
+++ b/scripts/sync-google-calendar.mjs
@@ -38,9 +38,13 @@ function formatDateToken(date) {
   )}${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}`;
 }
 
-function buildSlug(summary, startTime, uid) {
+function buildSlug(summary, startTime, uid, recurrenceId) {
   const base = summary ? toSlug(summary) : "arrangement";
   if (uid) {
+    const tokenSource = recurrenceId ?? startTime;
+    if (tokenSource) {
+      return `${base}-${uid.split("@")[0]}-${formatDateToken(tokenSource)}`;
+    }
     return `${base}-${uid.split("@")[0]}`;
   }
   if (startTime) {
@@ -64,32 +68,85 @@ function isCancelled(event) {
 async function run() {
   console.log(`Fetching calendar from ${CALENDAR_URL}`);
   const calendarData = await ical.async.fromURL(CALENDAR_URL);
-  const events = Object.values(calendarData).filter(
+  const vevents = Object.values(calendarData).filter(
     (entry) => entry?.type === "VEVENT",
   );
 
-  const records = events.map((event) => {
-    const title = event.summary?.trim() || "Arrangement";
-    const description = event.description?.trim() || "";
-    const startTime = toIsoDate(event.start);
-    const endTime = toIsoDate(event.end);
-    const slug = buildSlug(title, event.start, event.uid);
-    const status = isCancelled(event) ? "cancelled" : "published";
+  const rangeStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const rangeEnd = new Date(now.getTime() + 180 * 24 * 60 * 60 * 1000);
 
-    return {
-      slug,
-      title: { no: title, en: title },
-      description_md: {
-        no: description,
-        en: description,
-      },
-      start_time: startTime,
-      end_time: endTime,
-      location: event.location?.trim() || null,
-      status,
-      published_at: status === "published" ? now.toISOString() : null,
-    };
-  });
+  const recordsMap = new Map();
+
+  // 1. Process all explicit events (non-recurring and overrides)
+  for (const event of vevents) {
+    if (event.recurrenceid || !event.rrule) {
+      const title = event.summary?.trim() || "Arrangement";
+      const description = event.description?.trim() || "";
+      const startTime = toIsoDate(event.start);
+      const endTime = toIsoDate(event.end);
+      const slug = buildSlug(title, event.start, event.uid, event.recurrenceid);
+      const status = isCancelled(event) ? "cancelled" : "published";
+
+      recordsMap.set(slug, {
+        slug,
+        title: { no: title, en: title },
+        description_md: { no: description, en: description },
+        start_time: startTime,
+        end_time: endTime,
+        location: event.location?.trim() || null,
+        status,
+        published_at: status === "published" ? now.toISOString() : null,
+      });
+    }
+  }
+
+  // 2. Expand recurring master events
+  for (const event of vevents) {
+    if (event.rrule) {
+      const occurrences = event.rrule.between(rangeStart, rangeEnd);
+      const duration =
+        event.start && event.end
+          ? event.end.getTime() - event.start.getTime()
+          : 0;
+
+      for (const occurrence of occurrences) {
+        const title = event.summary?.trim() || "Arrangement";
+        const slug = buildSlug(title, occurrence, event.uid);
+
+        // Skip if this occurrence is already handled by an explicit override
+        if (recordsMap.has(slug)) continue;
+
+        // Skip if this occurrence is an exclusion date (EXDATE)
+        if (event.exdate) {
+          const occStr = occurrence.toISOString().split("T")[0];
+          const isExcluded = Object.keys(event.exdate).some((ex) =>
+            ex.startsWith(occStr),
+          );
+          if (isExcluded) continue;
+        }
+
+        const startTime = toIsoDate(occurrence);
+        const endTime =
+          duration > 0
+            ? toIsoDate(new Date(occurrence.getTime() + duration))
+            : startTime;
+        const description = event.description?.trim() || "";
+
+        recordsMap.set(slug, {
+          slug,
+          title: { no: title, en: title },
+          description_md: { no: description, en: description },
+          start_time: startTime,
+          end_time: endTime,
+          location: event.location?.trim() || null,
+          status: "published",
+          published_at: now.toISOString(),
+        });
+      }
+    }
+  }
+
+  const records = Array.from(recordsMap.values());
 
   if (!records.length) {
     console.log("No events found to sync.");


### PR DESCRIPTION
The Google Calendar integration was failing to show upcoming events primarily because it didn't expand recurring rules (RRULE). Most events in the calendar were recurring masters starting in the past, which were hidden by the 'start_time >= now' filter.

Changes:
1.  **RRULE Expansion:** The sync logic now expands recurring events for a window of 1 month in the past to 6 months in the future.
2.  **Unique Slugs:** Slugs for recurring instances now include a date token, preventing collisions and ensuring each instance has its own URL.
3.  **Override Handling:** Modified instances (overrides) in the iCal feed are correctly prioritized over generated occurrences.
4.  **Frontend UX:** The events query now uses an OR condition on `start_time` and `end_time` to ensure events currently in progress or all-day events for the current day remain visible.
5.  **Consistency:** Ensured that the standalone `sync-google-calendar.mjs` script and the Vercel API route use the same logic.

---
*PR created automatically by Jules for task [14325623895657852936](https://jules.google.com/task/14325623895657852936) started by @basstian-ai*