### PR TITLE
Add rotating upcoming-events ticker beneath homepage header

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,41 +1,53 @@
+import type { Route } from 'next';
+import { cookies } from 'next/headers';
+import Image from 'next/image';
+import Link from 'next/link';
 
-import type { Route } from "next";
-import { cookies } from "next/headers";
-import Image from "next/image";
-import Link from "next/link";
-
-import { buttonVariants } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { BodyText, Heading, Subheading } from "@/components/ui/typography";
+import { buttonVariants } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { EventTicker } from '@/components/ui/event-ticker';
+import { BodyText, Heading, Subheading } from '@/components/ui/typography';
 import {
   getLatestPosts,
   getUpcomingEvents,
   normalizeLocale,
   resolveLocalizedField,
-} from "@/lib/data";
-import { resolvePublicImageUrl } from "@/lib/utils/media";
+} from '@/lib/data';
+import { resolvePublicImageUrl } from '@/lib/utils/media';
 
 export const revalidate = 600;
 
 const quickLinks: Array<{ title: string; description: string; href: Route }> = [
-  { title: "Gi", description: "Støtt arbeidet med et engangsgave eller fast støtte.", href: "/gi" },
-  { title: "Besøk oss", description: "Finn tid, sted og praktisk informasjon.", href: "/om-oss" },
-  { title: "Meld deg på", description: "Påmelding til samlinger og arrangement.", href: "/kalender" },
+  {
+    title: 'Gi',
+    description: 'Støtt arbeidet med et engangsgave eller fast støtte.',
+    href: '/gi',
+  },
+  {
+    title: 'Besøk oss',
+    description: 'Finn tid, sted og praktisk informasjon.',
+    href: '/om-oss',
+  },
+  {
+    title: 'Meld deg på',
+    description: 'Påmelding til samlinger og arrangement.',
+    href: '/kalender',
+  },
 ];
 
-const fallbackLocale = "no";
+const fallbackLocale = 'no';
 
 const defaultEventImage =
-  "https://lfwpymqsqyuqevwuujkx.supabase.co/storage/v1/object/public/images/IMG_0395.png";
+  'https://lfwpymqsqyuqevwuujkx.supabase.co/storage/v1/object/public/images/IMG_0395.png';
 const defaultPostImage = defaultEventImage;
 
 const formatEventDate = (date: string) =>
-  new Intl.DateTimeFormat("nb-NO", {
-    weekday: "long",
-    day: "numeric",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
+  new Intl.DateTimeFormat('nb-NO', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
   }).format(new Date(date));
 
 type HomePageProps = {
@@ -43,46 +55,55 @@ type HomePageProps = {
 };
 
 export default async function HomePage({ searchParams }: HomePageProps) {
-  const cookieLocale = cookies().get("lang")?.value;
-  const searchLocale = typeof searchParams?.lang === "string" ? searchParams.lang : null;
+  const cookieLocale = cookies().get('lang')?.value;
+  const searchLocale =
+    typeof searchParams?.lang === 'string' ? searchParams.lang : null;
   const locale = normalizeLocale(searchLocale ?? cookieLocale, fallbackLocale);
   const [upcomingEvents, latestPosts] = await Promise.all([
-    getUpcomingEvents(1),
+    getUpcomingEvents(3),
     getLatestPosts(3),
   ]);
   const nextEvent = upcomingEvents[0] ?? null;
   const nextEventTitle =
-    resolveLocalizedField(nextEvent?.title, locale, fallbackLocale) ?? "Neste samling";
+    resolveLocalizedField(nextEvent?.title, locale, fallbackLocale) ??
+    'Neste samling';
   const nextEventDescription =
     resolveLocalizedField(nextEvent?.description_md, locale, fallbackLocale) ??
-    "Vi oppdaterer programmet snart. Følg med for detaljer om neste arrangement.";
-  const nextEventDate = nextEvent?.start_time ? formatEventDate(nextEvent.start_time) : null;
-  const nextEventLocation = nextEvent?.location ?? "Sted annonseres snart";
-  const nextEventImage = resolvePublicImageUrl(nextEvent?.cover_image_path) ?? defaultEventImage;
+    'Vi oppdaterer programmet snart. Følg med for detaljer om neste arrangement.';
+  const nextEventDate = nextEvent?.start_time
+    ? formatEventDate(nextEvent.start_time)
+    : null;
+  const nextEventLocation = nextEvent?.location ?? 'Sted annonseres snart';
+  const nextEventImage =
+    resolvePublicImageUrl(nextEvent?.cover_image_path) ?? defaultEventImage;
+  const tickerEvents = upcomingEvents.map((event) => ({
+    id: event.id,
+    title:
+      resolveLocalizedField(event.title, locale, fallbackLocale) ??
+      'Arrangement',
+    dateLabel: formatEventDate(event.start_time),
+    location: event.location ?? 'Sted annonseres snart',
+    href: `/kalender/${event.slug}`,
+  }));
 
   return (
     <div>
+      <EventTicker items={tickerEvents} />
       <section className="bg-[#fffaf3]">
         <div className="container-layout grid gap-10 py-16 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
           <div className="space-y-6">
             <div className="inline-flex items-center gap-2 rounded-full bg-brand-50 px-4 py-1 text-sm font-medium text-brand-700">
-              {nextEventDate ? `Neste samling · ${nextEventDate}` : "Neste samling oppdateres"}
+              {nextEventDate
+                ? `Neste samling · ${nextEventDate}`
+                : 'Neste samling oppdateres'}
             </div>
             <Heading>Kirke midt i byen, mennesker i sentrum.</Heading>
-            <BodyText>
-              {nextEventDescription}
-            </BodyText>
+            <BodyText>{nextEventDescription}</BodyText>
             <div className="flex flex-wrap gap-3">
-              <Link
-                className={buttonVariants("primary")}
-                href="/kalender"
-              >
+              <Link className={buttonVariants('primary')} href="/kalender">
                 Se kalender
               </Link>
-              <Link
-                className={buttonVariants("secondary")}
-                href="/kontakt"
-              >
+              <Link className={buttonVariants('secondary')} href="/kontakt">
                 Bli med i fellesskapet
               </Link>
             </div>
@@ -98,13 +119,16 @@ export default async function HomePage({ searchParams }: HomePageProps) {
               />
             </div>
             <div className="space-y-2">
-              <p className="text-sm uppercase tracking-[0.2em] text-stone-500">Denne uken</p>
+              <p className="text-sm uppercase tracking-[0.2em] text-stone-500">
+                Denne uken
+              </p>
               <Subheading>{nextEventTitle}</Subheading>
-              <BodyText>{nextEventDate ? `${nextEventDate} · ${nextEventLocation}` : "Ingen publiserte arrangementer enda."}</BodyText>
-              <Link
-                className={buttonVariants("ghost")}
-                href="/kalender"
-              >
+              <BodyText>
+                {nextEventDate
+                  ? `${nextEventDate} · ${nextEventLocation}`
+                  : 'Ingen publiserte arrangementer enda.'}
+              </BodyText>
+              <Link className={buttonVariants('ghost')} href="/kalender">
                 Se kalender
               </Link>
             </div>
@@ -118,13 +142,15 @@ export default async function HomePage({ searchParams }: HomePageProps) {
           <BodyText>Hold av tid til neste samling i fellesskapet.</BodyText>
         </div>
         <Card className="space-y-3">
-          <h3 className="text-lg font-semibold text-stone-900">{nextEventTitle}</h3>
+          <h3 className="text-lg font-semibold text-stone-900">
+            {nextEventTitle}
+          </h3>
           <BodyText>
             {nextEventDate
               ? `${nextEventDate} · ${nextEventLocation}`
-              : "Neste arrangement legges ut snart. Sjekk kalenderen for oppdateringer."}
+              : 'Neste arrangement legges ut snart. Sjekk kalenderen for oppdateringer.'}
           </BodyText>
-          <Link className={buttonVariants("primary")} href="/kalender">
+          <Link className={buttonVariants('primary')} href="/kalender">
             Se hele kalenderen
           </Link>
         </Card>
@@ -138,13 +164,14 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         <div className="grid gap-6 md:grid-cols-3">
           {quickLinks.map((link) => (
             <Card key={link.title} className="space-y-3">
-              <h3 className="text-lg font-semibold text-stone-900">{link.title}</h3>
+              <h3 className="text-lg font-semibold text-stone-900">
+                {link.title}
+              </h3>
               <BodyText>{link.description}</BodyText>
 
-              <Link className={buttonVariants("ghost")} href={link.href}>
+              <Link className={buttonVariants('ghost')} href={link.href}>
                 Gå til {link.title.toLowerCase()}
               </Link>
-
             </Card>
           ))}
         </div>
@@ -154,35 +181,40 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         <div className="container-layout space-y-8 py-14">
           <div className="flex items-center justify-between">
             <Subheading>Siste nyheter</Subheading>
-            <Link className={buttonVariants("secondary")} href="/nyheter">
+            <Link className={buttonVariants('secondary')} href="/nyheter">
               Se alle nyheter
             </Link>
-
           </div>
           <div className="grid gap-6 md:grid-cols-3">
             {latestPosts.length ? (
               latestPosts.map((post) => {
                 const title =
-                  resolveLocalizedField(post.title, locale, fallbackLocale) ?? "Nyhet";
+                  resolveLocalizedField(post.title, locale, fallbackLocale) ??
+                  'Nyhet';
                 const excerpt =
                   resolveLocalizedField(post.excerpt, locale, fallbackLocale) ??
-                  "Siste oppdateringer fra Bykirken kommer snart.";
+                  'Siste oppdateringer fra Bykirken kommer snart.';
 
                 return (
                   <Card key={post.id} className="space-y-3">
                     <div className="relative h-40 overflow-hidden rounded-xl">
                       <Image
-                        src={resolvePublicImageUrl(post.cover_image_path) ?? defaultPostImage}
+                        src={
+                          resolvePublicImageUrl(post.cover_image_path) ??
+                          defaultPostImage
+                        }
                         alt={title}
                         fill
                         sizes="(max-width: 768px) 100vw, 33vw"
                         className="object-cover"
                       />
                     </div>
-                    <h3 className="text-lg font-semibold text-stone-900">{title}</h3>
+                    <h3 className="text-lg font-semibold text-stone-900">
+                      {title}
+                    </h3>
                     <BodyText>{excerpt}</BodyText>
                     <Link
-                      className={buttonVariants("ghost")}
+                      className={buttonVariants('ghost')}
                       href={`/nyheter/${post.slug}`}
                     >
                       Les mer
@@ -192,9 +224,12 @@ export default async function HomePage({ searchParams }: HomePageProps) {
               })
             ) : (
               <Card className="space-y-3 md:col-span-3">
-                <h3 className="text-lg font-semibold text-stone-900">Ingen nyheter enda</h3>
+                <h3 className="text-lg font-semibold text-stone-900">
+                  Ingen nyheter enda
+                </h3>
                 <BodyText>
-                  Vi jobber med nye historier og oppdateringer. Kom tilbake snart!
+                  Vi jobber med nye historier og oppdateringer. Kom tilbake
+                  snart!
                 </BodyText>
               </Card>
             )}

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -83,7 +83,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       'Arrangement',
     dateLabel: formatEventDate(event.start_time),
     location: event.location ?? 'Sted annonseres snart',
-    href: `/kalender/${event.slug}`,
+    href: `/kalender/${event.slug}` as Route,
   }));
 
   return (

--- a/components/ui/event-ticker.tsx
+++ b/components/ui/event-ticker.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+type EventTickerItem = {
+  id: string;
+  title: string;
+  dateLabel: string;
+  location: string;
+  href: string;
+};
+
+type EventTickerProps = {
+  items: EventTickerItem[];
+};
+
+export function EventTicker({ items }: EventTickerProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (items.length < 2) {
+      return;
+    }
+
+    const tickerInterval = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % items.length);
+    }, 4500);
+
+    return () => {
+      window.clearInterval(tickerInterval);
+    };
+  }, [items.length]);
+
+  if (!items.length) {
+    return null;
+  }
+
+  const activeItem = items[activeIndex];
+
+  return (
+    <section className="border-b border-[#e6ddcf] bg-[#f3ece1]">
+      <div className="container-layout py-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-600">
+          Kommende eventer
+        </p>
+        <div className="relative mt-1 min-h-[2rem]">
+          <div key={activeItem.id}>
+            <Link
+              href={activeItem.href}
+              className="text-sm text-stone-700 transition hover:text-stone-950"
+            >
+              <span className="font-semibold">{activeItem.title}</span>
+              <span className="mx-2 text-stone-400">•</span>
+              <span>{activeItem.dateLabel}</span>
+              <span className="mx-2 text-stone-400">•</span>
+              <span>{activeItem.location}</span>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/event-ticker.tsx
+++ b/components/ui/event-ticker.tsx
@@ -20,6 +20,12 @@ export function EventTicker({ items }: EventTickerProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
+    setActiveIndex((current) =>
+      current >= items.length ? Math.max(items.length - 1, 0) : current,
+    );
+  }, [items.length]);
+
+  useEffect(() => {
     if (items.length < 2) {
       return;
     }

--- a/components/ui/event-ticker.tsx
+++ b/components/ui/event-ticker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import type { Route } from 'next';
 import { useEffect, useState } from 'react';
 
 type EventTickerItem = {
@@ -8,7 +9,7 @@ type EventTickerItem = {
   title: string;
   dateLabel: string;
   location: string;
-  href: string;
+  href: Route;
 };
 
 type EventTickerProps = {


### PR DESCRIPTION
### Motivation
- Surface the next three upcoming events prominently as a small rotating ticker under the header so visitors see upcoming activity at a glance.
- Reuse the existing homepage event data while preserving the current hero card for the single “next” event.

### Description
- Add a new client component `EventTicker` at `components/ui/event-ticker.tsx` that cycles through provided items every 4.5s and renders title, formatted date, location and a link.
- Update `app/(public)/page.tsx` to fetch `getUpcomingEvents(3)` instead of 1, map the events into ticker items (localized title, `formatEventDate`, location, and `/kalender/{slug}` link) and render `<EventTicker items={tickerEvents} />` directly below the header.
- Keep the existing hero section behavior by still using the first upcoming event for the main card.

### Testing
- Ran `npm run lint` and received no ESLint warnings or errors (success).
- Started the dev server (`npm run dev`) and attempted page load, but rendering returned a 500 due to missing Supabase `URL`/`KEY` environment variables (failure to fully validate in local environment).
- Attempted an automated browser screenshot with Playwright, but the page returned 500 for the same missing Supabase configuration (artifact captured but page not rendering expected content).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a2a68d674832494fffcecd15675ed)