### PR TITLE
Accept Vercel Cron Bearer token for Google Calendar sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Prosjektet har en API-route på `/api/google-calendar-sync` og en cron-konfig i 
 For å få dette til å kjøre i produksjon:
 1. Legg inn `SUPABASE_URL` og `SUPABASE_SERVICE_ROLE_KEY` i Vercel (Production + Preview).
 2. (Valgfritt) Sett `GOOGLE_CALENDAR_ICS_URL` hvis du vil overstyre kalender-URL.
-3. Sett `CRON_SECRET` og bruk den for kall til API-ruten (`/api/google-calendar-sync?secret=...` eller `x-cron-secret` header).
+3. Sett `CRON_SECRET`. Vercel Cron sender denne som `Authorization: Bearer <CRON_SECRET>`, og ruten støtter også `x-cron-secret` header eller `/api/google-calendar-sync?secret=...` for manuell testing.
 
 
 ### Supabase (milepæl 2)

--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -206,8 +206,14 @@ async function syncGoogleCalendar() {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
+  const authorizationHeader = request.headers.get("authorization");
+  const bearerToken = authorizationHeader?.startsWith("Bearer ")
+    ? authorizationHeader.slice(7).trim()
+    : null;
   const token =
-    request.headers.get("x-cron-secret") || searchParams.get("secret");
+    request.headers.get("x-cron-secret") ||
+    bearerToken ||
+    searchParams.get("secret");
   const isVercelCron = request.headers.has("x-vercel-cron");
   const isProduction = process.env.NODE_ENV === "production";
 


### PR DESCRIPTION
### Motivation
- Vercel Cron sends the secret as a Bearer token which caused valid scheduled requests to be rejected with 401 by the calendar sync route when `CRON_SECRET` was set.

### Description
- Parse `Authorization: Bearer <CRON_SECRET>` in the `/api/google-calendar-sync` GET handler (in addition to `x-cron-secret` and `?secret=`) and update the README to document that Vercel sends the cron secret as a Bearer token (`app/api/google-calendar-sync/route.ts` and `README.md`).

### Testing
- Ran `npm run lint` and the lint pass completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a4551fb4883249e53f2ed5978b8f9)