### PR TITLE
Externalize node-ical to fix Google Calendar sync crash

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true,
+    serverComponentsExternalPackages: ["node-ical"],
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
### Motivation
- Prevent `node-ical` and its Temporal/BigInt-related dependency chain from being webpack-bundled into server chunks (which caused `TypeError: o.BigInt is not a function` during Google Calendar imports on Vercel). 

### Description
- Add `serverComponentsExternalPackages: ["node-ical"]` under the `experimental` section in `next.config.mjs` so `node-ical` is loaded as an external server package at runtime instead of being bundled. 

### Testing
- Ran a production build with placeholder env vars using `SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npm run build`, which compiled successfully and produced an API route that imports `node-ical` via a runtime `require` (verifying the package is externalized); the build still shows an unrelated prerender `fetch failed` error for `/podcast` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a47e00881883249620610328e418e5)