### PR TITLE
Gracefully handle missing sync columns, adjust upsert/reconciliation logic, and expose node-ical for server components

### DIFF
--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -89,17 +89,21 @@ function isWithinRange(date: Date | undefined, rangeStart: Date, rangeEnd: Date)
   return date >= rangeStart && date <= rangeEnd;
 }
 
-function isMissingSyncColumnError(
+function getMissingSyncColumns(
   error: { code?: string; message?: string; details?: string; hint?: string } | null,
 ) {
   const isMissingColumnCode = error?.code === "42703";
   const isMissingSchemaCacheCode = error?.code === "PGRST204";
   const errorText = [error?.message, error?.details, error?.hint].join(" ").toLowerCase();
 
-  return (
-    (isMissingColumnCode || isMissingSchemaCacheCode) &&
-    (errorText.includes("sync_source") || errorText.includes("external_uid"))
-  );
+  if (!isMissingColumnCode && !isMissingSchemaCacheCode) {
+    return { missingSyncSource: false, missingExternalUid: false };
+  }
+
+  return {
+    missingSyncSource: errorText.includes("sync_source"),
+    missingExternalUid: errorText.includes("external_uid"),
+  };
 }
 
 async function syncGoogleCalendar() {
@@ -222,44 +226,67 @@ async function syncGoogleCalendar() {
 
   const records = Array.from(recordsMap.values());
 
-  let supportsSyncMetadata = true;
+  let supportsSyncSource = true;
 
   if (records.length) {
-    const recordsWithSource = records.map((record) => ({
+    const recordsWithSyncMetadata = records.map((record) => ({
       ...record,
       sync_source: SYNC_SOURCE,
     }));
 
-    const { error: upsertWithSourceError } = await supabase
+    const { error: upsertWithSyncMetadataError } = await supabase
       .from("events")
-      .upsert(recordsWithSource, { onConflict: "slug" });
+      .upsert(recordsWithSyncMetadata, { onConflict: "slug" });
 
-    if (upsertWithSourceError) {
-      if (!isMissingSyncColumnError(upsertWithSourceError)) {
-        throw upsertWithSourceError;
-      }
-
-      supportsSyncMetadata = false;
-      console.warn(
-        "Events table is missing sync_source/external_uid columns. Falling back to upsert-only sync without deletion reconciliation.",
+    if (upsertWithSyncMetadataError) {
+      const { missingExternalUid, missingSyncSource } = getMissingSyncColumns(
+        upsertWithSyncMetadataError,
       );
 
-      const { error: legacyUpsertError } = await supabase
-        .from("events")
-        .upsert(
-          records.map(({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord),
-          { onConflict: "slug" },
+      if (!missingExternalUid && !missingSyncSource) {
+        throw upsertWithSyncMetadataError;
+      }
+
+      if (missingSyncSource) {
+        supportsSyncSource = false;
+        console.warn(
+          "Events table is missing sync_source. Falling back to legacy upsert-only sync without deletion reconciliation.",
         );
 
-      if (legacyUpsertError) {
-        throw legacyUpsertError;
+        const { error: legacyUpsertError } = await supabase
+          .from("events")
+          .upsert(
+            records.map(({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord),
+            { onConflict: "slug" },
+          );
+
+        if (legacyUpsertError) {
+          throw legacyUpsertError;
+        }
+      } else {
+        console.warn(
+          "Events table is missing external_uid. Continuing sync with sync_source metadata only.",
+        );
+
+        const { error: upsertWithoutExternalUidError } = await supabase
+          .from("events")
+          .upsert(
+            recordsWithSyncMetadata.map(({ external_uid: _externalUid, ...record }) =>
+              record,
+            ),
+            { onConflict: "slug" },
+          );
+
+        if (upsertWithoutExternalUidError) {
+          throw upsertWithoutExternalUidError;
+        }
       }
     }
   }
 
   let reconciled = 0;
 
-  if (supportsSyncMetadata) {
+  if (supportsSyncSource) {
     const syncedSlugs = new Set(records.map((record) => record.slug));
     const { data: existingGoogleEvents, error: existingEventsError } = await supabase
       .from("events")

--- a/app/api/google-calendar-sync/route.ts
+++ b/app/api/google-calendar-sync/route.ts
@@ -278,7 +278,30 @@ async function syncGoogleCalendar() {
           );
 
         if (upsertWithoutExternalUidError) {
-          throw upsertWithoutExternalUidError;
+          const { missingSyncSource: missingSyncSourceOnRetry } =
+            getMissingSyncColumns(upsertWithoutExternalUidError);
+
+          if (!missingSyncSourceOnRetry) {
+            throw upsertWithoutExternalUidError;
+          }
+
+          supportsSyncSource = false;
+          console.warn(
+            "Events table is also missing sync_source. Falling back to legacy upsert-only sync without deletion reconciliation.",
+          );
+
+          const { error: legacyUpsertError } = await supabase
+            .from("events")
+            .upsert(
+              records.map(
+                ({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord,
+              ),
+              { onConflict: "slug" },
+            );
+
+          if (legacyUpsertError) {
+            throw legacyUpsertError;
+          }
         }
       }
     }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true,
+    serverComponentsExternalPackages: ["node-ical"],
   },
   images: {
     remotePatterns: [

--- a/scripts/sync-google-calendar.mjs
+++ b/scripts/sync-google-calendar.mjs
@@ -66,17 +66,21 @@ function isCancelled(event) {
   return event?.status?.toLowerCase?.() === "cancelled";
 }
 
-function isMissingSyncColumnError(error) {
+function getMissingSyncColumns(error) {
   const isMissingColumnCode = error?.code === "42703";
   const isMissingSchemaCacheCode = error?.code === "PGRST204";
   const errorText = [error?.message, error?.details, error?.hint]
     .join(" ")
     .toLowerCase();
 
-  return (
-    (isMissingColumnCode || isMissingSchemaCacheCode) &&
-    (errorText.includes("sync_source") || errorText.includes("external_uid"))
-  );
+  if (!isMissingColumnCode && !isMissingSchemaCacheCode) {
+    return { missingSyncSource: false, missingExternalUid: false };
+  }
+
+  return {
+    missingSyncSource: errorText.includes("sync_source"),
+    missingExternalUid: errorText.includes("external_uid"),
+  };
 }
 
 async function run() {
@@ -169,44 +173,67 @@ async function run() {
     return;
   }
 
-  const recordsWithSource = records.map((record) => ({
+  const recordsWithSyncMetadata = records.map((record) => ({
     ...record,
     sync_source: SYNC_SOURCE,
   }));
 
-  const { error: upsertWithSourceError } = await supabase
+  const { error: upsertWithSyncMetadataError } = await supabase
     .from("events")
-    .upsert(recordsWithSource, { onConflict: "slug" });
+    .upsert(recordsWithSyncMetadata, { onConflict: "slug" });
 
-  let supportsSyncMetadata = true;
+  let supportsSyncSource = true;
 
-  if (upsertWithSourceError) {
-    if (!isMissingSyncColumnError(upsertWithSourceError)) {
-      throw upsertWithSourceError;
-    }
-
-    supportsSyncMetadata = false;
-    console.warn(
-      "Events table is missing sync_source/external_uid columns. Falling back to upsert-only sync without deletion reconciliation.",
+  if (upsertWithSyncMetadataError) {
+    const { missingExternalUid, missingSyncSource } = getMissingSyncColumns(
+      upsertWithSyncMetadataError,
     );
 
-    const { error: legacyUpsertError } = await supabase
-      .from("events")
-      .upsert(
-        records.map(
-          ({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord,
-        ),
-        { onConflict: "slug" },
+    if (!missingExternalUid && !missingSyncSource) {
+      throw upsertWithSyncMetadataError;
+    }
+
+    if (missingSyncSource) {
+      supportsSyncSource = false;
+      console.warn(
+        "Events table is missing sync_source. Falling back to legacy upsert-only sync without deletion reconciliation.",
       );
 
-    if (legacyUpsertError) {
-      throw legacyUpsertError;
+      const { error: legacyUpsertError } = await supabase
+        .from("events")
+        .upsert(
+          records.map(
+            ({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord,
+          ),
+          { onConflict: "slug" },
+        );
+
+      if (legacyUpsertError) {
+        throw legacyUpsertError;
+      }
+    } else {
+      console.warn(
+        "Events table is missing external_uid. Continuing sync with sync_source metadata only.",
+      );
+
+      const { error: upsertWithoutExternalUidError } = await supabase
+        .from("events")
+        .upsert(
+          recordsWithSyncMetadata.map(
+            ({ external_uid: _externalUid, ...record }) => record,
+          ),
+          { onConflict: "slug" },
+        );
+
+      if (upsertWithoutExternalUidError) {
+        throw upsertWithoutExternalUidError;
+      }
     }
   }
 
   let reconciledCount = 0;
 
-  if (supportsSyncMetadata) {
+  if (supportsSyncSource) {
     const syncedSlugs = new Set(records.map((record) => record.slug));
     const { data: existingGoogleEvents, error: existingEventsError } =
       await supabase

--- a/scripts/sync-google-calendar.mjs
+++ b/scripts/sync-google-calendar.mjs
@@ -226,7 +226,30 @@ async function run() {
         );
 
       if (upsertWithoutExternalUidError) {
-        throw upsertWithoutExternalUidError;
+        const { missingSyncSource: missingSyncSourceOnRetry } =
+          getMissingSyncColumns(upsertWithoutExternalUidError);
+
+        if (!missingSyncSourceOnRetry) {
+          throw upsertWithoutExternalUidError;
+        }
+
+        supportsSyncSource = false;
+        console.warn(
+          "Events table is also missing sync_source. Falling back to legacy upsert-only sync without deletion reconciliation.",
+        );
+
+        const { error: legacyUpsertError } = await supabase
+          .from("events")
+          .upsert(
+            records.map(
+              ({ external_uid: _externalUid, ...legacyRecord }) => legacyRecord,
+            ),
+            { onConflict: "slug" },
+          );
+
+        if (legacyUpsertError) {
+          throw legacyUpsertError;
+        }
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Make the Google Calendar sync tolerant of databases missing `sync_source` or `external_uid` so the sync does not fail outright and can fall back to compatible behaviors.
- Ensure `node-ical` is available to server components by declaring it in the Next.js external packages config.

### Description
- Replace the boolean `isMissingSyncColumnError` check with `getMissingSyncColumns` which returns `{ missingSyncSource, missingExternalUid }` to detect each missing column separately.
- Update upsert logic to branch on column availability: if `sync_source` is missing fallback to legacy upsert (no reconciliation), if `external_uid` is missing continue using `sync_source` but upsert without `external_uid`, and otherwise throw on unexpected errors.
- Rename variables and error identifiers to clarify intent (`recordsWithSyncMetadata`, `upsertWithSyncMetadataError`, `supportsSyncSource`) and gate deletion reconciliation on `supportsSyncSource`.
- Add `serverComponentsExternalPackages: ["node-ical"]` to `next.config.mjs` so the `node-ical` package can be used from server components.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a47e00881883249620610328e418e5)